### PR TITLE
Fix nuxt type error (WIP)

### DIFF
--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -192,7 +192,6 @@
 </template>
 
 <script>
-import * as moment from 'moment';
 import { Constants, Sorts, Calendar, Day, Units, Weekday, Month, DaySpan, PatternMap, Time, Op } from 'dayspan';
 
 export default {
@@ -479,8 +478,7 @@ export default {
 
     setToday()
     {
-      const around = Day.fromMoment(moment().startOf('isoWeek'));
-      this.rebuild( around);
+      this.rebuild(this.$dayspan.today);
     },
 
     viewDay(day)

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -2,8 +2,8 @@
 
   <dayspan-custom-calendar
     :calendar="calendar"
-    :types="types"
     :read-only="true"
+    :types="calendarTypes"
     @change="calendarChanged"/>
 
 </template>
@@ -27,25 +27,22 @@ export default {
     DayspanCustomCalendar
   },
   data() {
-    const around = Day.fromMoment(moment().startOf('isoWeek'));
-    const calendarWeekType = {
+    const calendarTypeWeek = {
       id: 'W',
       label: 'Woche',
       shortcut: 'W',
-      type: Units.DAY,
-      size: 7,
-      around,
-      focus: 0,
+      type: Units.WEEK,
+      size: 1,
+      focus: 0.4999,
       repeat: true,
       listTimes: true,
       updateRows: true,
-      schedule: false
+      schedule: false,
     };
-    const calendar = Calendar.days(7, around, 0);
+
     return {
-      calendar,
-      types: [ calendarWeekType ],
-      aboutDialogOpen: false,
+      calendar: Calendar.weeks(),
+      calendarTypes: [calendarTypeWeek],
       loading: false,
     };
   },


### PR DESCRIPTION
So geht's, aber dann startet die Woche an einem Sonntag.
Wir sollten eine andere Lösung finden, um den Kalender Montag beginnen zu lassen - meine Lösung ist nur ein Workaround gewesen.
Offiziell wird es nicht unterstützt: https://github.com/ClickerMonkey/dayspan-vuetify/issues/82
Der Fehler hängt hiermit zusammen: https://github.com/nuxt/nuxt.js/issues/3731
@BrainConverter wir müssten dafür dayspan-vuetify anpassen.