### PR TITLE
Custom schedule

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-dialog
+    v-model="dialogOpen"
+    :fullscreen="$vuetify.breakpoint.smAndDown"
+    max-width="800px"
+    hide-overlay
+    transition="dialog-bottom-transition">
+    <v-card>
+      <v-toolbar
+        dark
+        color="primary">
+        <v-btn
+          icon
+          dark
+          @click.native="dialogOpen = false">
+          <v-icon>close</v-icon>
+        </v-btn>
+        <v-toolbar-title>Neuer Stundenplan</v-toolbar-title>
+        <v-spacer />
+        <v-toolbar-items>
+          <v-btn
+            dark
+            flat
+            @click.native="dialogOpen = false">Speichern</v-btn>
+        </v-toolbar-items>
+      </v-toolbar>
+      <v-container>
+        <v-layout
+          row
+          wrap>
+          <v-flex>
+            <v-text-field
+              v-model="timetableName"
+              label="Plan benennen"
+              single-line />
+          </v-flex>
+
+          <v-flex xs12>
+            <v-text-field
+              v-model="search"
+              append-icon="search"
+              label="Kurs suchen"
+              single-line
+              hide-details />
+            <v-data-table
+              v-model="timetableCourses"
+              :headers="headers"
+              :items="courses"
+              :search="search"
+              hide-headers
+              hide-actions
+              item-key="title">
+              <template
+                slot="items"
+                slot-scope="props">
+                <td>
+                  <v-checkbox
+                    v-model="props.selected"
+                    primary
+                    hide-details />
+                </td>
+                <td>{{ props.item.title }}</td>
+                <td>{{ props.item.lecturer }}</td>
+                <td v-show="$vuetify.breakpoint.smAndUp">{{ props.item.room }}</td>
+              </template>
+            </v-data-table>
+          </v-flex>
+        </v-layout>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import { mapMutations, mapState, mapGetters, mapActions } from 'vuex';
+
+export default {
+  name: 'CustomTimetableDialog',
+  props: {
+    value: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      headers: [
+        { text: 'Titel', value: 'title' },
+        { text: 'Dozent', value: 'lecturer' },
+        { text: 'Raum', value: 'room' },
+      ],
+      search: '',
+      timetableCourses: [],
+      timetableName: '',
+    };
+  },
+  computed: {
+    dialogOpen: {
+      get() { return this.value; },
+      set(value) { this.$emit('input', value); }
+    },
+    ...mapGetters({
+      courses: 'splus/getCourses',
+    }),
+  },
+};
+</script>

--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -17,32 +17,32 @@
       </v-list-tile-content>
     </v-list-tile>
 
+    <v-list-tile @click="customTimetableDialogOpen = true">
+      <custom-timetable-dialog v-model="customTimetableDialogOpen" />
+      <v-list-tile-action>
+        <v-icon>add</v-icon>
+      </v-list-tile-action>
+      <v-list-tile-content>
+        <v-list-tile-title>Plan erstellen</v-list-tile-title>
+      </v-list-tile-content>
+    </v-list-tile>
+
   </v-list>    
 
 </template>
 
 <script lang="js">
-  export default  {
-    name: 'CustomTimetablesList',
-    data() {
-      return {
+import CustomTimetableDialog from './custom-timetable-dialog.vue';
 
-      }
-    },
-    computed: {
-
-    },
-    mounted() {
-
-    },
-    methods: {
-
+export default {
+  name: 'CustomTimetablesList',
+  components: {
+    CustomTimetableDialog,
+  },
+  data() {
+    return {
+      customTimetableDialogOpen: false,
     }
+  },
 }
 </script>
-
-<style scoped lang="scss">
-  .my-timetables-component {
-
-  }
-</style>

--- a/store/splus.js
+++ b/store/splus.js
@@ -82,6 +82,13 @@ export const getters = {
       };
     });
   },
+  getCourses: (state) => {
+    const lectureToId = (lecture) => lecture.title.split(' ')[0];
+    const allLectures = [].concat(...Object.values(state.lectures));
+    const uniqueLectures = new Map();
+    allLectures.forEach((lecture) => uniqueLectures.set(lectureToId(lecture), lecture));
+    return [...uniqueLectures.values()];
+  },
 };
 
 export const mutations = {


### PR DESCRIPTION
Ich habe ein Modal geschrieben, in dem man einen Titel eingeben kann und aus einer Liste von Kursen auswählen kann. Die Liste von Kursen kann man durchsuchen. Das Modal lässt sich über den drawer öffnen. Auf mobilen Geräten ist der Dialog im Vollbildmodus.

Die Kursliste ist nur ein Platzhalter, die muss serverseitig generiert werden. Den eigenen Plan zu speichern geht aus gleichem Grund auch noch nicht. Das möchte ich in einem separaten PR machen um möglichst kleinschrittig zu arbeiten.

Edit: Wollen wir "schedule" oder "timetable" als Terminologie verwenden? timetable ist britisch, schedule amerikanisch.