### PR TITLE
Fix no lectures on page load after static build

### DIFF
--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -65,6 +65,12 @@ export default {
     'currentSchedule': 'loadLectures',
     'currentWeek': 'loadLectures',
   },
+  mounted() {
+    if (this.events.length == 0) {
+      // static build -> store has not been filled yet
+      this.loadLectures();
+    }
+  },
   methods: {
     calendarChanged({ calendar }) {
       this.setWeek(calendar.start.date.isoWeek());

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,7 +21,10 @@ export default {
     SpluseinsFooter
   },
   async fetch({ store }) {
-    await store.dispatch('splus/load');
+    if (!process.static) {
+      // not for static build because it depends on the current timestamp
+      await store.dispatch('splus/load');
+    }
   },
 }
 </script>


### PR DESCRIPTION
Für Netlify wird das HTML in einem statischen build einmalig gerendert. Zu dem Zeitpunkt des renderns werden die Daten für die aktuelle Woche aus der API geladen. Der Client ruft die Daten nicht noch einmal ab.
Die Folge: Ist der build eine Woche her, ist der Plan leer.
Mit diesem PR wird eine Ausnahme für den statischen build hinzugefügt und im Client werden die Daten abgerufen, wenn sie noch nicht vorhanden sind.