### PR TITLE
Make view state shareable, Add multiple custom schedules

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -60,6 +60,7 @@
 <script lang="js">
 import { mapMutations, mapState, mapGetters, mapActions } from 'vuex';
 import * as moment from 'moment';
+import { uniq, customScheduleToRoute } from '../store/splus';
 import TimetableSelect from './timetable-select.vue';
 import CourseMultiselect from './course-multiselect.vue';
 
@@ -140,17 +141,23 @@ export default {
     },
     save() {
       this.dialogOpen = false;
-      this.saveCustomSchedule({
-        schedule: this.selectedSchedule,
-        courses: this.selectedCourses,
-        name: this.selectedName,
-      });
+
+      // Set the base schedule and filters matching the given courses.
+      const titleIds = uniq(this.selectedCourses.map(({ titleId }) => titleId));
+
+      const schedule = this.selectedSchedule;
+      const customSchedule = {
+        id: schedule.id,
+        faculty: schedule.faculty,
+        semester: schedule.semester,
+        label: this.selectedName,
+        whitelist: titleIds,
+      };
+
+      this.$router.push(customScheduleToRoute(customSchedule));
     },
     ...mapMutations({
       setError: 'splus/setError',
-    }),
-    ...mapActions({
-      saveCustomSchedule: 'splus/saveCustomSchedule',
     }),
   },
 };

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -33,7 +33,7 @@
             <v-flex xs12>
               <v-text-field
                 v-model="selectedName"
-                :rules="[rules.required]"
+                :rules="[rules.required, rules.uniqueCustomScheduleLabel]"
                 label="Plan benennen"
                 single-line
                 required
@@ -86,6 +86,9 @@ export default {
       valid: false,
       rules: {
         required: (value) => !!value || 'Pflichtfeld',
+        uniqueCustomScheduleLabel:
+          (value) => !this.customScheduleLabels.includes(value)
+                     || 'Bereits vergeben',
       },
     };
   },
@@ -110,6 +113,7 @@ export default {
     }),
     ...mapGetters({
       schedulesTree: 'splus/getSchedulesAsTree',
+      customScheduleLabels: 'splus/customScheduleLabels',
     }),
   },
   watch: {

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="js">
-import { mapMutations, mapState, mapGetters } from 'vuex';
+import { mapMutations, mapState, mapGetters, mapActions } from 'vuex';
 import * as moment from 'moment';
 import TimetableSelect from './timetable-select.vue';
 import CourseMultiselect from './course-multiselect.vue';
@@ -140,18 +140,18 @@ export default {
     },
     save() {
       this.dialogOpen = false;
-      this.setCustomSchedule({
+      this.saveCustomSchedule({
         schedule: this.selectedSchedule,
         courses: this.selectedCourses,
         name: this.selectedName,
       });
-      this.setSchedule(this.customSchedule);
     },
     ...mapMutations({
       setError: 'splus/setError',
-      setCustomSchedule: 'splus/setCustomSchedule',
-      setSchedule: 'splus/setSchedule',
     }),
-  }
+    ...mapActions({
+      saveCustomSchedule: 'splus/saveCustomSchedule',
+    }),
+  },
 };
 </script>

--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -13,9 +13,6 @@
       <v-list-tile-content>
         <v-list-tile-title>{{ customSchedule.label }}</v-list-tile-title>
       </v-list-tile-content>
-      <v-list-tile-action v-if="currentSchedule.label == customSchedule.label">
-        <v-icon>check</v-icon>
-      </v-list-tile-action>
     </v-list-tile>
 
     <v-list-tile
@@ -51,7 +48,6 @@ export default {
   computed: {
     ...mapState({
       customSchedule: (state) => state.splus.customSchedule,
-      currentSchedule: (state) => state.splus.schedule,
     }),
     ...mapGetters({
       customScheduleAsRoute: 'splus/customScheduleAsRoute',

--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -7,16 +7,16 @@
     </v-subheader>
 
     <v-list-tile
-      v-if="!!customSchedule"
-      :to="customScheduleAsRoute"
+      v-for="route in customSchedulesAsRoutes"
+      :key="route.query.name"
+      :to="route"
       nuxt>
       <v-list-tile-content>
-        <v-list-tile-title>{{ customSchedule.label }}</v-list-tile-title>
+        <v-list-tile-title>{{ route.query.name }}</v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
 
     <v-list-tile
-      v-else
       @click="customTimetableDialogOpen = true">
       <custom-timetable-dialog v-model="customTimetableDialogOpen" />
       <v-list-tile-action>
@@ -50,7 +50,7 @@ export default {
       customSchedule: (state) => state.splus.customSchedule,
     }),
     ...mapGetters({
-      customScheduleAsRoute: 'splus/customScheduleAsRoute',
+      customSchedulesAsRoutes: 'splus/customSchedulesAsRoutes',
     }),
   },
 };

--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -8,11 +8,12 @@
 
     <v-list-tile
       v-if="!!customSchedule"
-      @click="setCurrentSchedule(customSchedule)">
+      :to="customScheduleAsRoute"
+      nuxt>
       <v-list-tile-content>
         <v-list-tile-title>{{ customSchedule.label }}</v-list-tile-title>
       </v-list-tile-content>
-      <v-list-tile-action v-if="currentSchedule == customSchedule">
+      <v-list-tile-action v-if="currentSchedule.label == customSchedule.label">
         <v-icon>check</v-icon>
       </v-list-tile-action>
     </v-list-tile>
@@ -34,7 +35,7 @@
 </template>
 
 <script lang="js">
-import { mapState, mapMutations } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import CustomTimetableDialog from './custom-timetable-dialog.vue';
 
 export default {
@@ -49,14 +50,12 @@ export default {
   },
   computed: {
     ...mapState({
-      currentSchedule: (state) => state.splus.schedule,
       customSchedule: (state) => state.splus.customSchedule,
+      currentSchedule: (state) => state.splus.schedule,
+    }),
+    ...mapGetters({
+      customScheduleAsRoute: 'splus/customScheduleAsRoute',
     }),
   },
-  methods: {
-    ...mapMutations({
-      setCurrentSchedule: 'splus/setSchedule',
-    }),
-  }
 };
 </script>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -32,7 +32,7 @@
 
           <v-list-tile
             v-for="schedule in schedules"
-            :to="{ params: { schedule: schedule.id } }"
+            :to="scheduleToRoute(schedule)"
             :key="schedule.id"
             nuxt>
             <v-list-tile-content value="true">
@@ -43,7 +43,7 @@
 
         <v-list-tile
           v-else
-          :to="{ params: { schedule: schedules[0].id } }"
+          :to="scheduleToRoute(schedules[0])"
           :key="semester"
           nuxt>
           <v-list-tile-content>
@@ -69,5 +69,13 @@ export default {
       schedulesTree: 'splus/getSchedulesAsTree',
     }),
   },
+  methods: {
+    scheduleToRoute(schedule) {
+      return {
+        name: 'schedule',
+        params: { schedule: schedule.id },
+      };
+    },
+  }
 };
 </script>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -35,7 +35,7 @@
 
           <v-list-tile
             v-for="schedule in schedules"
-            :to="`/${schedule.id}`"
+            :to="{ params: { schedule: schedule.id } }"
             :key="schedule.id"
             nuxt>
             <v-list-tile-content value="true">
@@ -49,7 +49,7 @@
 
         <v-list-tile
           v-else
-          :to="`/${schedules[0].id}`"
+          :to="{ params: { schedule: schedules[0].id } }"
           :key="semester"
           nuxt>
           <v-list-tile-content>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -28,9 +28,6 @@
               <v-list-tile-title v-if="semester == 'WPF'">Wahlpflichtfächer</v-list-tile-title>
               <v-list-tile-title v-else>{{ semester }}. Semester</v-list-tile-title>
             </v-list-tile-content>
-            <v-list-tile-action v-if="currentSemester == semester && currentSchedulePath == path">
-              <v-icon color="primary">check</v-icon>
-            </v-list-tile-action>
           </v-list-tile>
 
           <v-list-tile
@@ -41,9 +38,6 @@
             <v-list-tile-content value="true">
               <v-list-tile-title value="true">{{ schedule.label }}</v-list-tile-title>
             </v-list-tile-content>
-            <v-list-tile-action v-if="currentSchedule == schedule">
-              <v-icon color="primary">check</v-icon>
-            </v-list-tile-action>
           </v-list-tile>
         </v-list-group>
 
@@ -56,9 +50,6 @@
             <v-list-tile-title v-if="semester == 'WPF'">Wahlpflichtfächer</v-list-tile-title>
             <v-list-tile-title v-else>{{ semester }}. Semester</v-list-tile-title>
           </v-list-tile-content>
-          <v-list-tile-action v-if="currentSchedule == schedules[0]">
-            <v-icon>check</v-icon>
-          </v-list-tile-action>
         </v-list-tile>
       </template>
 
@@ -69,29 +60,14 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapMutations } from 'vuex';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'GeneralTimetablesList',
   computed: {
-    currentSemester() {
-      return !!this.currentSchedule ? this.currentSchedule.semester : '';
-    },
-    currentSchedulePath() {
-      return !!this.currentSchedule ? this.currentSchedule.path : '';
-    },
-    ...mapState({
-      currentSchedule: (state) => state.splus.schedule,
-      schedules: (state) => state.splus.schedules,
-    }),
     ...mapGetters({
       schedulesTree: 'splus/getSchedulesAsTree',
     }),
-  },
-  methods: {
-    ...mapMutations({
-      setCurrentSchedule: 'splus/setSchedule',
-    })
   },
 };
 </script>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -35,8 +35,9 @@
 
           <v-list-tile
             v-for="schedule in schedules"
+            :to="`/${schedule.id}`"
             :key="schedule.id"
-            @click="setCurrentSchedule(schedule)">
+            nuxt>
             <v-list-tile-content value="true">
               <v-list-tile-title value="true">{{ schedule.label }}</v-list-tile-title>
             </v-list-tile-content>
@@ -48,8 +49,9 @@
 
         <v-list-tile
           v-else
+          :to="`/${schedules[0].id}`"
           :key="semester"
-          @click="setCurrentSchedule(schedules[0])">
+          nuxt>
           <v-list-tile-content>
             <v-list-tile-title v-if="semester == 'WPF'">Wahlpflichtfächer</v-list-tile-title>
             <v-list-tile-title v-else>{{ semester }}. Semester</v-list-tile-title>

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -50,8 +50,9 @@ export default {
   },
   computed: {
     ...mapState({
-      currentSchedule: state => state.splus.schedule,
-      currentWeek: state => state.splus.week,
+      currentSchedule: (state) => state.splus.schedule,
+      currentWeek: (state) => state.splus.week,
+      lazyLoad: (state) => state.splus.lazyLoad,
     }),
     ...mapGetters({
       events: 'splus/getLecturesAsEvents',
@@ -64,8 +65,8 @@ export default {
     'currentWeek': 'loadLectures',
   },
   mounted() {
-    if (this.events.length == 0) {
-      // static build -> store has not been filled yet
+    if (this.lazyLoad) {
+      // static build -> no lectures are in the store
       this.loadLectures();
     }
   },

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -20,7 +20,6 @@ import DayspanCustomCalendar from './dayspan-custom-calendar.vue'
 
 export default {
   name: 'SpluseinsCalendar',
-  layout: 'empty',
   components: {
     DayspanCustomCalendar
   },

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -62,7 +62,6 @@ export default {
     'events': function(events) {
       this.calendar.setEvents(events);
     },
-    'currentSchedule': 'loadLectures',
     'currentWeek': 'loadLectures',
   },
   mounted() {

--- a/components/spluseins-side-nav.vue
+++ b/components/spluseins-side-nav.vue
@@ -14,8 +14,6 @@
 </template>
 
 <script lang="js">
-import { mapState } from 'vuex';
-
 import GeneralTimetablesList from './general-timetables-list.vue';
 import FavoriteTimetablesList from './favorite-timetables-list.vue';
 import CustomTimetablesList from './custom-timetables-list.vue';
@@ -37,15 +35,6 @@ export default {
     drawerProp: {
       get() { return this.drawer; },
       set(val) { this.$emit('update:drawer', val); }
-    },
-    ...mapState({
-      currentSchedule: (state) => state.splus.schedule,
-    }),
-  },
-  watch: {
-    currentSchedule() {
-      // close drawer when navigation target changes by clicking on a list item
-      this.drawerProp = false;
     },
   },
 };

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,39 @@
 <template>
-  <nuxt />
+  <v-app :dark="isDark">
+    <spluseins-header/>
+    <v-content fill-height>
+
+      <nuxt />
+  
+      <spluseins-error-snackbar />
+      <no-ssr>
+        <!-- no ssr: show/hide depends on client's local storage settings -->
+        <spluseins-cookie-snackbar />
+      </no-ssr>
+    </v-content>
+    <spluseins-footer/>
+  </v-app>
 </template>
 
 <script>
-export default { };
+import { mapState } from 'vuex';
+
+import SpluseinsHeader from '../components/spluseins-header.vue';
+import SpluseinsFooter from '../components/spluseins-footer.vue';
+import SpluseinsErrorSnackbar from '../components/spluseins-error-snackbar.vue';
+import SpluseinsCookieSnackbar from '../components/spluseins-cookie-snackbar.vue';
+
+export default {
+  components: {
+    SpluseinsHeader,
+    SpluseinsFooter,
+    SpluseinsErrorSnackbar,
+    SpluseinsCookieSnackbar,
+  },
+  computed: {
+    ...mapState({
+      isDark: state => state.theme.isDark,
+    }),
+  },
+};
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,7 @@
 const pkg = require('./package');
+const schedules = require('./assets/schedules.json');
 
-module.exports = {
+export default {
   mode: 'universal',
 
   /*
@@ -70,5 +71,13 @@ module.exports = {
         })
       }
     }
-  }
+  },
+
+  /*
+  ** Generate configuration
+  */
+  generate: {
+    fallback: true,
+    routes: schedules.map(({ id }) => `/${id}`),
+  },
 }

--- a/pages/_schedule.vue
+++ b/pages/_schedule.vue
@@ -1,83 +1,31 @@
 <template>
-  <v-app :dark="isDark">
-    <spluseins-header/>
-    <v-content fill-height>
-      <v-container
-        fluid
-        fill-height>
-        <spluseins-calendar v-if="!!schedule" />
-
-        <v-layout
-          v-else
-          row
-          align-center
-          justify-center>
-          <v-flex
-            class="text-xs-center"
-            xs12>
-            <v-icon>settings</v-icon>
-            <p>Leer. Wähle einen Plan aus dem Menü aus.</p>
-          </v-flex>
-        </v-layout>
-      </v-container>
-      <spluseins-error-snackbar />
-      <no-ssr>
-        <!-- no ssr: show/hide depends on client's local storage settings -->
-        <spluseins-cookie-snackbar />
-      </no-ssr>
-    </v-content>
-    <spluseins-footer/>
-  </v-app>
+  <v-container
+    fluid
+    fill-height>
+    <spluseins-calendar />
+  </v-container>
 </template>
 
 <script>
-import { mapState } from 'vuex';
-
-import SpluseinsHeader from '../components/spluseins-header.vue';
 import SpluseinsCalendar from '../components/spluseins-calendar.vue';
-import SpluseinsFooter from '../components/spluseins-footer.vue';
-import SpluseinsErrorSnackbar from '../components/spluseins-error-snackbar.vue';
-import SpluseinsCookieSnackbar from '../components/spluseins-cookie-snackbar.vue';
 
 export default {
-  name: 'HomePage',
+  name: 'SchedulePage',
   components: {
-    SpluseinsHeader,
     SpluseinsCalendar,
-    SpluseinsFooter,
-    SpluseinsErrorSnackbar,
-    SpluseinsCookieSnackbar,
-  },
-  computed: {
-    ...mapState({
-      schedule: state => state.splus.schedule,
-      isDark: state => state.theme.isDark,
-    }),
   },
   async fetch({ store, params, query }) {
-    if (!!params.schedule) {
-      store.dispatch('splus/importSchedule', { params, query });
+    store.dispatch('splus/importSchedule', { params, query });
 
-      if (process.static) {
-        store.commit('splus/enableLazyLoad');
-      }
+    if (process.static) {
+      store.commit('splus/enableLazyLoad');
+    }
 
-      if (!store.state.splus.lazyLoad) {
-        await store.dispatch('splus/load');
-      } else {
-        console.log('lazy loading is enabled: not fetching any lectures');
-      }
+    if (!store.state.splus.lazyLoad) {
+      await store.dispatch('splus/load');
+    } else {
+      console.log('lazy loading is enabled: not fetching any lectures');
     }
   },
 };
 </script>
-
-
-<style scoped lang="scss">
-
-.container {
-  padding: 16px 16px 25px 16px;
-}
-
-</style>
-

--- a/pages/_schedule.vue
+++ b/pages/_schedule.vue
@@ -54,14 +54,17 @@ export default {
       isDark: state => state.theme.isDark,
     }),
   },
-  async fetch({ store, params }) {
+  async fetch({ store, params, query }) {
     const scheduleId = params.schedule;
 
     if (!!scheduleId) {
-      const schedule =  store.state.splus.schedules
-        .find((schedule) => schedule.id == scheduleId);
-
-      store.commit('splus/setSchedule', schedule);
+      if (!!query.v) {
+        store.dispatch('splus/importCustomSchedule', { params, query });
+      } else {
+        const schedule =  store.state.splus.schedules
+          .find((schedule) => schedule.id == scheduleId);
+        store.commit('splus/setSchedule', schedule);
+      }
 
       // exclude static build
       // because loaded schedule depends on the current timestamp

--- a/pages/_schedule.vue
+++ b/pages/_schedule.vue
@@ -57,10 +57,15 @@ export default {
   async fetch({ store, params, query }) {
     if (!!params.schedule) {
       store.dispatch('splus/importSchedule', { params, query });
-      // exclude static build
-      // because loaded schedule depends on the current timestamp
-      if (!process.static) {
+
+      if (process.static) {
+        store.commit('splus/enableLazyLoad');
+      }
+
+      if (!store.state.splus.lazyLoad) {
         await store.dispatch('splus/load');
+      } else {
+        console.log('lazy loading is enabled: not fetching any lectures');
       }
     }
   },

--- a/pages/_schedule.vue
+++ b/pages/_schedule.vue
@@ -55,17 +55,8 @@ export default {
     }),
   },
   async fetch({ store, params, query }) {
-    const scheduleId = params.schedule;
-
-    if (!!scheduleId) {
-      if (!!query.v) {
-        store.dispatch('splus/importCustomSchedule', { params, query });
-      } else {
-        const schedule =  store.state.splus.schedules
-          .find((schedule) => schedule.id == scheduleId);
-        store.commit('splus/setSchedule', schedule);
-      }
-
+    if (!!params.schedule) {
+      store.dispatch('splus/importSchedule', { params, query });
       // exclude static build
       // because loaded schedule depends on the current timestamp
       if (!process.static) {

--- a/pages/_schedule.vue
+++ b/pages/_schedule.vue
@@ -54,10 +54,20 @@ export default {
       isDark: state => state.theme.isDark,
     }),
   },
-  async fetch({ store }) {
-    if (!process.static && !!store.state.splus.schedule) {
-      // not for static build because it depends on the current timestamp
-      await store.dispatch('splus/load');
+  async fetch({ store, params }) {
+    const scheduleId = params.schedule;
+
+    if (!!scheduleId) {
+      const schedule =  store.state.splus.schedules
+        .find((schedule) => schedule.id == scheduleId);
+
+      store.commit('splus/setSchedule', schedule);
+
+      // exclude static build
+      // because loaded schedule depends on the current timestamp
+      if (!process.static) {
+        await store.dispatch('splus/load');
+      }
     }
   },
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-container
+    fluid
+    fill-height>
+    <v-layout
+      row
+      align-center
+      justify-center>
+      <v-flex
+        class="text-xs-center"
+        xs12>
+        <v-icon>settings</v-icon>
+        <p>Leer. Wähle einen Plan aus dem Menü aus.</p>
+      </v-flex>
+    </v-layout>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'IndexPage',
+};
+</script>

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -10,7 +10,7 @@ export default ({ store }) => {
       /* select items to be persisted - must not change the structure! */
       theme: state.theme,
       splus: {
-        customSchedule: state.splus.customSchedule,
+        customSchedules: state.splus.customSchedules,
       },
       privacy: {
         allowCookies: state.privacy.allowCookies,

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -8,6 +8,7 @@ export default ({ store }) => {
       storage.setItem(key, JSON.stringify(state)),
     reducer: (state) => ({
       /* select items to be persisted - must not change the structure! */
+      version: state.version,
       theme: state.theme,
       splus: {
         customSchedules: state.splus.customSchedules,

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -10,7 +10,6 @@ export default ({ store }) => {
       /* select items to be persisted - must not change the structure! */
       theme: state.theme,
       splus: {
-        schedule: state.splus.schedule,
         customSchedule: state.splus.customSchedule,
       },
       privacy: {

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,8 @@
+export const state = () => ({
+  /**
+   * State schema version.
+   * Should be incremented if the store schema changes and local browser data
+   * needs to be migrated.
+   */
+  version: 1,
+});

--- a/store/splus.js
+++ b/store/splus.js
@@ -25,7 +25,7 @@ export function customScheduleToRoute(customSchedule) {
     v: 1
   };
 
-  return { params, query };
+  return { name: 'schedule', params, query };
 }
 
 export const state = () => ({

--- a/store/splus.js
+++ b/store/splus.js
@@ -5,6 +5,7 @@ import SCHEDULES from '~/assets/schedules.json';
 import * as chroma from 'chroma-js';
 
 export const uniq = (iterable) => [...new Set(iterable)];
+const flatten = (iterable) => [].concat(...iterable);
 const scalarArraysEqual = (array1, array2) =>
   array1.length === array2.length &&
   array1.every((value, index) => value === array2[index]);
@@ -80,7 +81,6 @@ export const getters = {
       return [];
     }
 
-    const flatten = (iterable) => [].concat(...iterable);
     const uniqueIds = uniq(flatten(Object.values(state.lectures))
       .map(({ lecturerId }) => lecturerId))
       .sort();
@@ -153,6 +153,9 @@ export const getters = {
   customSchedulesAsRoutes: (state, getters) => {
     return Object.values(state.customSchedules)
       .map(customScheduleToRoute);
+  },
+  customScheduleLabels: (state) => {
+    return Object.keys(state.customSchedules);
   },
 };
 

--- a/store/splus.js
+++ b/store/splus.js
@@ -134,11 +134,7 @@ export const mutations = {
   setWeek(state, week) {
     state.week = week;
   },
-  /**
-   * Set the schedule and clear the cache.
-   */
   setSchedule(state, schedule) {
-    state.lectures = {};
     state.schedule = schedule;
   },
   /**

--- a/store/splus.js
+++ b/store/splus.js
@@ -55,6 +55,11 @@ export const state = () => ({
    */
   week: moment().diff(isoWeek0, 'week'),
   error: undefined,
+  /**
+   * If true, do not load lectures on the server.
+   * true if frontend is a static build.
+   */
+  lazyLoad: false,
 });
 
 export const getters = {
@@ -187,6 +192,9 @@ export const mutations = {
   },
   clearError(state) {
     state.error = undefined;
+  },
+  enableLazyLoad(state) {
+    state.lazyLoad = true;
   },
 };
 


### PR DESCRIPTION
Follow-Up zu / hängt ab von #35

* Der erste Parameter der URL ist die Stundenplan-ID (Nuxt generiert dynamische Routen für Dateien mit Unterstrich, siehe https://nuxtjs.org/guide/routing)
  * Beispiel-URL: spluseins.de/SPLUSA2822D
  * Beim direkten Aufruf kann der Nuxt-Server die Seite direkt rendern!
  * In der Sidebar stehen jetzt Links. Deswegen schließt sie sich nach dem Wechseln des Plans.
  * Im Store werden die lectures beim schedule-Wechsel nicht mehr gelöscht, Nuxt leert den sowieso beim Seitenwechsel.

Nicht so cool:
 * [x] Der Doppel-Scrollbalken ist wieder aufgetaucht 🙁 working on it
 * [x] nuxt generate unterstützt dynamische URLs nicht. Die Netlify-Integration ist damit unbenutzbar.
 