### PR TITLE
Adjusted splus disclaimer position

### DIFF
--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -88,22 +88,10 @@ export default {
 <style scoped lang="scss">
 
 .overlay {
-  position: absolute;
+  display: flex;
+  justify-content: right;
   opacity: 0.5;
   font-size: 12px;
 }
 
-@media screen and (max-width: 1000px) {
-  .overlay {
-    right: 20px;
-    bottom: 15px;
-  }
-}
-
-@media screen and (min-width: 1000px) {
-  .overlay {
-    right: 45px;
-    bottom: 22px;
-  }
-}
 </style>

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -86,11 +86,24 @@ export default {
 </script>
 
 <style scoped lang="scss">
+
 .overlay {
   position: absolute;
-  right: 1.5em;
-  bottom: 1.5em;
   opacity: 0.5;
-  font-size: small;
+  font-size: 12px;
+}
+
+@media screen and (max-width: 1000px) {
+  .overlay {
+    right: 20px;
+    bottom: 15px;
+  }
+}
+
+@media screen and (min-width: 1000px) {
+  .overlay {
+    right: 45px;
+    bottom: 22px;
+  }
 }
 </style>

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -89,7 +89,7 @@ export default {
 
 .overlay {
   display: flex;
-  justify-content: right;
+  justify-content: flex-end;
   opacity: 0.5;
   font-size: 12px;
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,7 +61,7 @@ export default {
 <style scoped lang="scss">
 
 .container {
-  padding: 16px 16px 25px 16px !important;
+  padding: 16px 16px 25px 16px;
 }
 
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -56,3 +56,13 @@ export default {
   },
 };
 </script>
+
+
+<style scoped lang="scss">
+
+.container {
+  padding: 16px 16px 25px 16px !important;
+}
+
+</style>
+


### PR DESCRIPTION
- der Unterschied kam zustande, da die Scrollbar auf mobilen Geräten dünner ist als auf Fullsize Geräten
- lieber "px" als "em" benutzen weil sich "em" weitervererbet, das heißt "2em" sind dann in der nächsten Vererbungsstufe mit "2em" schon "4em"

**Tested on Laptop, Smartphone and Ipad**