### PR TITLE
Persist store state if permitted

### DIFF
--- a/components/__tests__/spluseins-cookie-snackbar.spec.ts
+++ b/components/__tests__/spluseins-cookie-snackbar.spec.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils';
+import * as Vue_ from 'vue';
+import * as Vuetify_ from 'vuetify';
+import * as Vuex_ from 'vuex';
+import SpluseinsCookieSnackbar from '../spluseins-cookie-snackbar.vue';
+import * as PrivacyModule from '../../store/privacy';
+
+const Vue: any = Vue_;
+const Vuetify: any = Vuetify_;
+const Vuex: any = Vuex_;
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+describe('Cookie snackbar', () => {
+  let store;
+
+  function mountWithState(allowCookies) {
+    const mutations = {
+      setCookiesAllowed: jest.fn(),
+      setCookiesDenied: jest.fn(),
+    };
+
+    store = new Vuex.Store({
+      modules: { privacy: {
+        state: { allowCookies },
+        mutations: PrivacyModule.mutations,
+        namespaced: true,
+      } }
+    });
+
+    return mount(SpluseinsCookieSnackbar, { store });
+  }
+
+  it('should render a snackbar by default', () => {
+    const wrapper = mountWithState(undefined);
+    expect(wrapper.contains('.v-snack')).toBeTruthy();
+  });
+
+  it('should not render a snackbar when consent was given or denied', () => {
+    let wrapper = mountWithState(true);
+    expect(wrapper.contains('.v-snack')).toBeFalsy();
+    wrapper = mountWithState(false);
+    expect(wrapper.contains('.v-snack')).toBeFalsy();
+  });
+
+  it('should mutate state after giving or denying consent', async () => {
+    let wrapper = mountWithState(undefined);
+    wrapper.find({ ref: 'btn-allow' }).trigger('click');
+    expect(store.state.privacy.allowCookies).toBe(true);
+
+    wrapper = mountWithState(undefined);
+    wrapper.find({ ref: 'btn-deny' }).trigger('click');
+    expect(store.state.privacy.allowCookies).toBe(false);
+  });
+});

--- a/components/__tests__/spluseins-error-snackbar.spec.ts
+++ b/components/__tests__/spluseins-error-snackbar.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils';
 import * as Vue_ from 'vue';
 import * as Vuetify_ from 'vuetify';
 import * as Vuex_ from 'vuex';
-import SpluseinsSnackbar from '../spluseins-snackbar.vue';
+import SpluseinsErrorSnackbar from '../spluseins-error-snackbar.vue';
 
 const Vue: any = Vue_;
 const Vuetify: any = Vuetify_;
@@ -11,12 +11,12 @@ const Vuex: any = Vuex_;
 Vue.use(Vuetify);
 Vue.use(Vuex);
 
-describe('Snackbar', () => {
+describe('Error snackbar', () => {
   function mountWithState(state) {
     const store = new Vuex.Store({
       modules: { splus: { state } }
     });
-    return mount(SpluseinsSnackbar, { store });
+    return mount(SpluseinsErrorSnackbar, { store });
   }
 
   it('should render no snackbar by default', () => {

--- a/components/spluseins-cookie-snackbar.vue
+++ b/components/spluseins-cookie-snackbar.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-snackbar
+    :value="snackbarOpen"
+    :timeout="0"
+    right>
+    Einstellungen im Browser speichern?
+    <v-layout
+      justify-space-between
+      fluid
+      row>
+      <v-btn
+        ref="btn-deny"
+        flat
+        icon
+        @click="setCookiesDenied()">
+        Nein
+      </v-btn>
+      <v-btn
+        ref="btn-allow"
+        color="success"
+        flat
+        @click="setCookiesAllowed()">
+        Erlauben
+      </v-btn>
+    </v-layout>
+  </v-snackbar>
+</template>
+
+<script>
+import { mapMutations, mapState } from 'vuex';
+
+export default {
+  name: 'SpluseinsCookieSnackbar',
+  computed: {
+    snackbarOpen() {
+      return this.allowCookies == undefined;
+    },
+    ...mapState({
+      allowCookies: state => state.privacy.allowCookies,
+    }),
+  },
+  methods: {
+    ...mapMutations({
+      setCookiesAllowed: 'privacy/setCookiesAllowed',
+      setCookiesDenied: 'privacy/setCookiesDenied',
+    }),
+  },
+};
+</script>

--- a/components/spluseins-error-snackbar.vue
+++ b/components/spluseins-error-snackbar.vue
@@ -17,7 +17,7 @@
 import { mapMutations, mapState } from 'vuex';
 
 export default {
-  name: 'SpluseinsSnackbar',
+  name: 'SpluseinsErrorSnackbar',
   computed: {
     snackbarOpen: {
         get() {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,7 +35,8 @@ module.exports = {
   ** Plugins to load before mounting the App
   */
   plugins: [
-    '@/plugins/vuetify'
+    '@/plugins/vuetify',
+    { src: '@/plugins/vuex-persist', ssr: false },
   ],
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,7 +2064,6 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -2542,7 +2541,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
       "requires": {
         "babel-core": "^6.26.0",
         "babel-runtime": "^6.26.0",
@@ -2557,7 +2555,6 @@
           "version": "6.26.3",
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-          "dev": true,
           "requires": {
             "babel-code-frame": "^6.26.0",
             "babel-generator": "^6.26.0",
@@ -2584,7 +2581,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2593,7 +2589,6 @@
           "version": "0.4.18",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
           "requires": {
             "source-map": "^0.5.6"
           }
@@ -3138,7 +3133,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -5772,13 +5767,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5791,18 +5784,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5905,8 +5895,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5916,7 +5905,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5929,20 +5917,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5959,7 +5944,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6032,8 +6016,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6043,7 +6026,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6149,7 +6131,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6619,7 +6600,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
@@ -8317,6 +8297,8 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
       "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
       "requires": {
+        "babel-core": "^6.0.0",
+        "babel-jest": "^22.4.4",
         "babel-plugin-istanbul": "^4.1.5",
         "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
@@ -8350,6 +8332,55 @@
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
+        "babel-core": {
+          "version": "6.26.3",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          }
+        },
+        "babel-jest": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+          "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+          "requires": {
+            "babel-plugin-istanbul": "^4.1.5",
+            "babel-preset-jest": "^22.4.4"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+          "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ=="
+        },
+        "babel-preset-jest": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+          "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+          "requires": {
+            "babel-plugin-jest-hoist": "^22.4.4",
+            "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+          }
+        },
         "braces": {
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
@@ -8358,6 +8389,14 @@
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
             "repeat-element": "^1.1.2"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -8875,6 +8914,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
@@ -9101,7 +9145,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -9585,9 +9629,9 @@
       }
     },
     "node-sass": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
-      "integrity": "sha512-MXyurANsUoE4/6KmfMkwGcBzAnJQ5xJBGW7Ei6ea8KnUKuzHr/SguVBIi3uaUAHtZCPUYkvlJ3Ef5T5VAwVpaA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
+      "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -10056,8 +10100,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -10072,8 +10115,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
@@ -13102,7 +13144,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -14436,6 +14478,22 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.0.1.tgz",
       "integrity": "sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w=="
+    },
+    "vuex-persist": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vuex-persist/-/vuex-persist-2.0.0.tgz",
+      "integrity": "sha512-BG5iOlthnXBCMp1tZpUTc/pvn+81fyEwx+1sYar1ktEZukbGHEsB5yIAydXeoWxUW416oj4/2Qfjrd/noqkoxQ==",
+      "requires": {
+        "circular-json": "^0.5.5",
+        "lodash.merge": "^4.6.1"
+      },
+      "dependencies": {
+        "circular-json": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+          "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
+        }
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "express": "^4.16.3",
     "moment": "^2.22.2",
     "nuxt": "^2.2.0",
-    "vuetify": "^1.3.5"
+    "vuetify": "^1.3.5",
+    "vuex-persist": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.5",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -20,7 +20,11 @@
           </v-flex>
         </v-layout>
       </v-container>
-      <spluseins-snackbar />
+      <spluseins-error-snackbar />
+      <no-ssr>
+        <!-- no ssr: show/hide depends on client's local storage settings -->
+        <spluseins-cookie-snackbar />
+      </no-ssr>
     </v-content>
     <spluseins-footer/>
   </v-app>
@@ -32,7 +36,8 @@ import { mapState } from 'vuex';
 import SpluseinsHeader from '../components/spluseins-header.vue';
 import SpluseinsCalendar from '../components/spluseins-calendar.vue';
 import SpluseinsFooter from '../components/spluseins-footer.vue';
-import SpluseinsSnackbar from '../components/spluseins-snackbar.vue';
+import SpluseinsErrorSnackbar from '../components/spluseins-error-snackbar.vue';
+import SpluseinsCookieSnackbar from '../components/spluseins-cookie-snackbar.vue';
 
 export default {
   name: 'HomePage',
@@ -40,7 +45,8 @@ export default {
     SpluseinsHeader,
     SpluseinsCalendar,
     SpluseinsFooter,
-    SpluseinsSnackbar,
+    SpluseinsErrorSnackbar,
+    SpluseinsCookieSnackbar,
   },
   computed: {
     ...mapState({

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -1,0 +1,20 @@
+import VuexPersistence from 'vuex-persist';
+
+export default ({ store }) => {
+  window.onNuxtReady(() => new VuexPersistence({
+    key: 'spluseins',
+    saveState: (key, state, storage) => !state.privacy.allowCookies ? undefined:
+      // pass through (https://github.com/championswimmer/vuex-persist/blob/master/src/index.ts#L211)
+      storage.setItem(key, JSON.stringify(state)),
+    reducer: (state) => ({
+      /* select items to be persisted - must not change the structure! */
+      theme: state.theme,
+      splus: {
+        schedule: state.splus.schedule,
+      },
+      privacy: {
+        allowCookies: state.privacy.allowCookies,
+      },
+    }),
+  }).plugin(store));
+};

--- a/store/privacy.js
+++ b/store/privacy.js
@@ -1,0 +1,16 @@
+export const state = () => ({
+  /**
+   * May store cookies.
+   * 3 state boolean™.
+   */
+  allowCookies: undefined,
+});
+
+export const mutations = {
+  setCookiesAllowed(state) {
+    state.allowCookies = true;
+  },
+  setCookiesDenied(state) {
+    state.allowCookies = false;
+  },
+};


### PR DESCRIPTION
Änderungen:
* Eine Teilmenge von store-Daten werden mit vuex-persist im LocalStorage des Browsers gespeichert.
 * DSGVO-verträglich wird vorher in einer Snackbar nach Zustimmung dafür gefragt.

Zum Testen könnt ihr `localStorage.clear()` in der Web-Konsole ausführen oder "Cookies und Browserdaten löschen" im Menü auswählen.

Für die Zukunft: Man kann den gesamten Storage damit abspeichern, das schließt die lectures aus der API ein. Damit hat man offline-Unterstützung! Wenn man das jetzt aber schon aktiviert, werden die Daten nie neu geladen und könnten out of date sein, das kommt also am besten in eine separate Story.

Wenn #45 gemerged ist, müssen die darin neu eingeführten store-Attribute auch selektiert werden.