### PR TITLE
Support custom schedules with multiple bases

### DIFF
--- a/components/course-multiselect.vue
+++ b/components/course-multiselect.vue
@@ -35,6 +35,7 @@
         <td>
           <v-checkbox
             v-model="props.selected"
+            :disabled="!props.selected && selectedCourses.length > maxCourses"
             primary
             hide-details />
         </td>
@@ -50,6 +51,10 @@
 export default {
   name: 'CourseMultiselect',
   props: {
+    maxCourses: {
+      type: Number,
+      default: () => Infinity,
+    },
     courses: {
       type: Array,
       default: () => []

--- a/components/course-multiselect.vue
+++ b/components/course-multiselect.vue
@@ -8,10 +8,8 @@
       hide-details />
     <v-data-table
       v-model="selectedCourses"
-      :headers="headers"
       :items="courses"
       :search="search"
-      :loading="loading"
       hide-headers
       hide-actions
       item-key="titleId">
@@ -19,12 +17,7 @@
         <v-layout
           row
           justify-center>
-          <v-progress-circular
-            v-show="loading"
-            slot="progress"
-            :indeterminate="true"
-            color="secondary" />
-          <p v-show="!loading">
+          <p>
             Keine Vorlesungen.
           </p>
         </v-layout>
@@ -63,18 +56,9 @@ export default {
       type: Array,
       default: () => []
     },
-    loading: {
-      type: Boolean,
-      default: false
-    },
   },
   data() {
     return {
-      headers: [
-        { text: 'Titel', value: 'title' },
-        { text: 'Dozent', value: 'lecturer' },
-        { text: 'Raum', value: 'room' },
-      ],
       search: '',
     };
   },

--- a/components/course-multiselect.vue
+++ b/components/course-multiselect.vue
@@ -21,6 +21,7 @@
           justify-center>
           <v-progress-circular
             v-show="loading"
+            slot="progress"
             :indeterminate="true"
             color="secondary" />
           <p v-show="!loading">
@@ -46,13 +47,8 @@
 </template>
 
 <script lang="js">
-import TimetableSelect from './timetable-select.vue';
-
 export default {
-  name: 'CustomTimetableDialog',
-  components: {
-    TimetableSelect,
-  },
+  name: 'CourseMultiselect',
   props: {
     courses: {
       type: Array,

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -33,7 +33,7 @@
             <v-flex xs12>
               <v-text-field
                 v-model="selectedName"
-                :rules="[rules.required, rules.uniqueCustomScheduleLabel]"
+                :rules="[rules.required, rules.uniqueScheduleLabel]"
                 label="Plan benennen"
                 single-line
                 required
@@ -99,8 +99,9 @@ export default {
       valid: false,
       rules: {
         required: (value) => !!value || 'Pflichtfeld',
-        uniqueCustomScheduleLabel:
-          (value) => !this.customScheduleLabels.includes(value)
+        uniqueScheduleLabel:
+          (value) => (!this.customScheduleLabels.includes(value)
+                      && !this.scheduleIds.includes(value))
                      || 'Bereits vergeben',
       },
       // reasonable limits to ensure good performance
@@ -127,6 +128,7 @@ export default {
     ...mapGetters({
       schedulesTree: 'splus/getSchedulesAsTree',
       customScheduleLabels: 'splus/customScheduleLabels',
+      scheduleIds: 'splus/scheduleIds',
     }),
   },
   methods: {

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -124,6 +124,10 @@ export default {
   },
   methods: {
     addSchedule(schedule) {
+      if (this.selectedSchedules.includes(schedule)) {
+        return;
+      }
+
       this.selectedSchedules.push(schedule);
       this.loadLectures(schedule);
     },

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -43,6 +43,7 @@
             <v-flex xs12>
               <timetable-select
                 v-show="selectedSchedules.length <= maxSchedules"
+                :loading="loading"
                 @input="addSchedule" />
             </v-flex>
 

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -41,7 +41,9 @@
             </v-flex>
 
             <v-flex xs12>
-              <timetable-select @input="addSchedule" />
+              <timetable-select
+                v-show="selectedSchedules.length <= maxSchedules"
+                @input="addSchedule" />
             </v-flex>
 
             <v-flex xs12>
@@ -57,6 +59,7 @@
             <v-flex xs12>
               <course-multiselect
                 v-model="selectedCourses"
+                :max-courses="maxCourses"
                 :courses="courses"
                 :loading="loading" />
             </v-flex>
@@ -100,6 +103,10 @@ export default {
           (value) => !this.customScheduleLabels.includes(value)
                      || 'Bereits vergeben',
       },
+      // reasonable limits to ensure good performance
+      // and a usable UI
+      maxSchedules: 5,
+      maxCourses: 20,
     };
   },
   computed: {

--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -8,11 +8,11 @@
 
     <v-list-tile
       v-for="route in customSchedulesAsRoutes"
-      :key="route.query.name"
+      :key="route.params.schedule"
       :to="route"
       nuxt>
       <v-list-tile-content>
-        <v-list-tile-title>{{ route.query.name }}</v-list-tile-title>
+        <v-list-tile-title>{{ route.params.schedule }}</v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
 

--- a/components/timetable-select.vue
+++ b/components/timetable-select.vue
@@ -38,6 +38,8 @@
         xs2
         md1>
         <v-btn
+          :disabled="loading"
+          :loading="loading"
           icon
           flat
           large
@@ -55,6 +57,12 @@ import { mapGetters } from 'vuex';
 
 export default {
   name: 'TimetableSelect',
+  props: {
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
   data() {
     return {
       valid: false,

--- a/components/timetable-select.vue
+++ b/components/timetable-select.vue
@@ -9,36 +9,33 @@
         <v-select
           :items="paths"
           v-model="selectedPath"
-          label="Studiengang"
-          required />
+          label="Studiengang" />
       </v-flex>
       <v-flex
         xs4
         md2>
         <v-select
           :items="semesters"
-          :rules="[rules.required]"
+          :disabled="selectedPath == undefined"
           v-model="selectedSemester"
-          label="Semester"
-          required />
+          label="Semester" />
       </v-flex>
       <v-flex
         xs6
         md4>
         <v-select
           :items="schedules"
-          :rules="[rules.resolvesToSchedule]"
+          :disabled="selectedSemester == undefined"
           v-model="selectedSchedule"
           label="Vertiefung"
           item-text="label"
-          required
           return-object />
       </v-flex>
       <v-flex
         xs2
         md1>
         <v-btn
-          :disabled="loading"
+          :disabled="loading || selectedSchedule == undefined"
           :loading="loading"
           icon
           flat
@@ -67,12 +64,8 @@ export default {
     return {
       valid: false,
       selectedSchedule: undefined,
-      selectedPath: '',
-      selectedSemester: '',
-      rules: {
-        required: (value) => !!value || 'Pflichtfeld',
-        resolvesToSchedule: () => !!this.selectedSchedule || 'Pflichtfeld',
-      },
+      selectedPath: undefined,
+      selectedSemester: undefined,
     };
   },
   computed: {
@@ -101,7 +94,7 @@ export default {
       if (this.semesters.length == 1) {
         this.selectedSemester = this.semesters[0];
       } else {
-        this.selectedSemester = '';
+        this.selectedSemester = undefined;
       }
     },
     selectedSemester() {

--- a/components/timetable-select.vue
+++ b/components/timetable-select.vue
@@ -1,39 +1,53 @@
 <template>
-  <v-layout
-    row
-    wrap>
-    <v-flex
-      md5
-      xs9>
-      <v-select
-        :items="paths"
-        v-model="selectedPath"
-        label="Studiengang"
-        required />
-    </v-flex>
-    <v-flex
-      md2
-      xs3>
-      <v-select
-        :items="semesters"
-        :rules="[rules.required]"
-        v-model="selectedSemester"
-        label="Semester"
-        required />
-    </v-flex>
-    <v-flex
-      v-show="!($vuetify.breakpoint.smAndDown && !hasMultipleSchedules)"
-      md5>
-      <v-select
-        :items="schedules"
-        :rules="[rules.resolvesToSchedule]"
-        v-model="selectedSchedule"
-        label="Vertiefung"
-        item-text="label"
-        required
-        return-object />
-    </v-flex>
-  </v-layout>
+  <v-form v-model="valid">
+    <v-layout
+      row
+      wrap>
+      <v-flex
+        xs12
+        md5>
+        <v-select
+          :items="paths"
+          v-model="selectedPath"
+          label="Studiengang"
+          required />
+      </v-flex>
+      <v-flex
+        xs4
+        md2>
+        <v-select
+          :items="semesters"
+          :rules="[rules.required]"
+          v-model="selectedSemester"
+          label="Semester"
+          required />
+      </v-flex>
+      <v-flex
+        xs6
+        md4>
+        <v-select
+          :items="schedules"
+          :rules="[rules.resolvesToSchedule]"
+          v-model="selectedSchedule"
+          label="Vertiefung"
+          item-text="label"
+          required
+          return-object />
+      </v-flex>
+      <v-flex
+        xs2
+        md1>
+        <v-btn
+          icon
+          flat
+          large
+          color="secondary"
+          @click.native="submit()">
+          <v-icon>add</v-icon>
+        </v-btn>
+      </v-flex>
+    </v-layout>
+  </v-form>
 </template>
 
 <script>
@@ -41,27 +55,19 @@ import { mapGetters } from 'vuex';
 
 export default {
   name: 'TimetableSelect',
-  props: {
-    value: {
-      type: Object,
-      default: () => undefined
-    },
-  },
   data() {
     return {
+      valid: false,
+      selectedSchedule: undefined,
       selectedPath: '',
       selectedSemester: '',
       rules: {
         required: (value) => !!value || 'Pflichtfeld',
         resolvesToSchedule: () => !!this.selectedSchedule || 'Pflichtfeld',
-      }
+      },
     };
   },
   computed: {
-    selectedSchedule: {
-      get() { return this.value; },
-      set(value) { this.$emit('input', value); }
-    },
     paths() {
       return Object.keys(this.schedulesTree);
     },
@@ -95,6 +101,13 @@ export default {
         this.selectedSchedule = this.schedules[0];
       } else {
         this.selectedSchedule = undefined;
+      }
+    },
+  },
+  methods: {
+    submit() {
+      if (this.valid) {
+        this.$emit('input', this.selectedSchedule);
       }
     },
   },

--- a/store/splus.js
+++ b/store/splus.js
@@ -215,7 +215,8 @@ export const actions = {
       state.schedule.id : [state.schedule.id];
 
     commit('clearLectures', { week: state.week });
-    
+
+    let allLectures = [];
     await Promise.all(ids.map(async (id) => {
       try {
         const response = await this.$axios.get(`/api/splus/${id}/${state.week}`);
@@ -227,12 +228,14 @@ export const actions = {
             (lecture1) => whitelist.includes(lecture1.titleId));
         }
 
-        commit('addLectures', { lectures, week: state.week });
+        allLectures = allLectures.concat(lectures);
       } catch (error) {
         commit('setError', 'API-Verbindung fehlgeschlagen');
         console.error('error during API call', error.message);
       }
     }));
+
+    commit('addLectures', { lectures: allLectures, week: state.week });
   },
   /**
    * Import schedule from route and set as current schedule.

--- a/store/splus.js
+++ b/store/splus.js
@@ -19,9 +19,11 @@ const isoWeek0 = moment()
 
 
 export function customScheduleToRoute(customSchedule) {
-  const params = { schedule: customSchedule.id };
+  const params = {
+    schedule: customSchedule.label,
+  };
   const query = {
-    name: customSchedule.label,
+    id: customSchedule.id,
     course: customSchedule.whitelist,
     v: 1
   };
@@ -161,8 +163,11 @@ export const getters = {
 
 export const mutations = {
   addLectures(state, { lectures, week }) {
-    // reactive variant of state.lectures[week] = lectures
-    Vue.set(state.lectures, week, lectures);
+    // reactive variant of state.lectures[week].push(lectures)
+    Vue.set(state.lectures, week, lectures.concat(state.lectures[week] || []));
+  },
+  clearLectures(state, { week }) {
+    Vue.set(state.lectures, week, []);
   },
   setWeek(state, week) {
     state.week = week;
@@ -203,41 +208,42 @@ export const mutations = {
 
 export const actions = {
   async load({ state, commit }) {
-    try {
-      const response = await this.$axios.get(`/api/splus/${state.schedule.id}/${state.week}`);
-      let lectures = response.data;
-      const whitelist = state.schedule.whitelist;
-      if (!!whitelist) {
-        lectures = lectures.filter(
-          (lecture1) => whitelist.includes(lecture1.titleId));
+    const ids = Array.isArray(state.schedule.id) ?
+      state.schedule.id : [state.schedule.id];
+
+    commit('clearLectures', { week: state.week });
+    
+    await Promise.all(ids.map(async (id) => {
+      try {
+        const response = await this.$axios.get(`/api/splus/${id}/${state.week}`);
+
+        let lectures = response.data;
+        const whitelist = state.schedule.whitelist;
+        if (!!whitelist) {
+          lectures = lectures.filter(
+            (lecture1) => whitelist.includes(lecture1.titleId));
+        }
+
+        commit('addLectures', { lectures, week: state.week });
+      } catch (error) {
+        commit('setError', 'API-Verbindung fehlgeschlagen');
+        console.error('error during API call', error.message);
       }
-      commit('addLectures', { lectures, week: state.week });
-    } catch (error) {
-      commit('setError', 'API-Verbindung fehlgeschlagen');
-      console.error('error during API call', error.message);
-    }
+    }));
   },
   /**
    * Import schedule from route and set as current schedule.
    */
   importSchedule({ state, commit }, { params, query }) {
-    const schedule = state.schedules
-      .find((schedule) => schedule.id == params.schedule);
-
     switch (parseFloat(query.v)) {
       case 1:
-        if (!query.name) {
-          console.log('missing custom schedule name', { query });
-          return;
-        }
-
         const courses = Array.isArray(query.course || []) ?
           query.course : [query.course];
+        const ids = Array.isArray(query.id || []) ?
+          query.id : [query.id];
         const customSchedule = {
-          id: schedule.id,
-          faculty: schedule.faculty,
-          semester: schedule.semester,
-          label: query.name,
+          id: ids,
+          label: params.schedule,
           whitelist: courses,
         };
 
@@ -248,6 +254,9 @@ export const actions = {
         if (!isNaN(query.v)) {
           console.log('unsupported custom schedule query version', query);
         }
+
+        const schedule = state.schedules
+          .find((schedule) => schedule.id == params.schedule);
 
         // standard, no filters
         commit('setSchedule', schedule);

--- a/store/splus.js
+++ b/store/splus.js
@@ -152,6 +152,9 @@ export const getters = {
 
     return tree;
   },
+  scheduleIds: (state) => {
+    return state.schedules.map(({ id }) => id);
+  },
   customSchedulesAsRoutes: (state, getters) => {
     return Object.values(state.customSchedules)
       .map(customScheduleToRoute);


### PR DESCRIPTION
Änderungen:
  * Im Dialog kann man mehrere Pläne in die Tabelle laden.
  * Das URL-Schema und das Laden eines eigenen Plans ist entsprechend angepasst.

Offene Probleme:
  * [x] Loading spinner in dem Dialog in der Kursliste wird nicht angezeigt, wenn man den zweiten Plan hinzulädt
  * [ ] Die Kursliste sollte sortiert sein
  * [ ] Der Code für eigene Pläne wird unübersichtlich und müsste ein bisschen aufgeräumt werden