### PR TITLE
Use subheader in lists to fix padding

### DIFF
--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -1,6 +1,6 @@
 <template lang="html">
 
-  <v-list>
+  <v-list subheader>
 
     <v-subheader>
       Eigene Pläne

--- a/components/favorite-timetables-list.vue
+++ b/components/favorite-timetables-list.vue
@@ -1,6 +1,6 @@
 <template lang="html">
 
-  <v-list>
+  <v-list subheader>
 
     <v-subheader>
       Favoriten

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -1,6 +1,6 @@
 <template lang="html">
 
-  <v-list>
+  <v-list subheader>
 
     <v-subheader>
       Alle Pläne

--- a/components/install-button-list.vue
+++ b/components/install-button-list.vue
@@ -1,7 +1,9 @@
 <template>
   <div v-show="visible">
     <v-divider />
-    <v-list dense>
+    <v-list
+      subheader
+      dense>
       <v-list-tile @click="install()">
         <v-list-tile-action>
           <v-icon>get_app</v-icon>


### PR DESCRIPTION
Wie von vuetify empfohlen. Damit ist der Abstand zwischen list subheader und divider nicht genau so groß wie zwischen subheader und nächstem Element.