### PR TITLE
Event text wrap

### DIFF
--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -839,4 +839,8 @@ export default {
 .ds-week .ds-day-today > div:not(.ds-hour):not(.v-menu) {
   border-top: 3px solid var(--v-primary-base) !important;
 }
+.ds-ev-description{
+  white-space: pre-wrap;
+}
+
 </style>

--- a/store/splus.js
+++ b/store/splus.js
@@ -127,7 +127,7 @@ export const getters = {
         data: {
           title: lecture.title,
           color, // needs to be a hex string
-          description: `${lecture.lecturer} ${lecture.room} ${lecture.info}`,
+          description: `\n${lecture.lecturer}\n${lecture.room} ${lecture.info}`,
           location: lecture.room,
         },
         schedule: {


### PR DESCRIPTION
Der Event-Text wird nun nach dem Titel und nach dem Dozenten umgebrochen.
So entstehen im besten Fall 3 Zeilen, oft aber mehr, da der Text zu lang ist.
Ab 4 Zeilen passt die Beschreibung bei 90 min Vorlesungen nicht mehr vollständig in das Event Fenster.

Ist erstmal eine vorübergehende Lösung.
Eine Idee wäre, dass man nur wichtige Dinge wie den Titel in das Event packt und den Rest über einen kleinen Info-Popup bekannt gibt.