### PR TITLE
Display parallel events side by side

### DIFF
--- a/plugins/dayspan.config.js
+++ b/plugins/dayspan.config.js
@@ -1,12 +1,13 @@
-export default {
+// see: https://github.com/ClickerMonkey/dayspan-vuetify/blob/master/src/component.js
 
+export default {
   data: {
     inactiveBlendAmount: 0.6,
   },
 
   methods:
   {
-      
+
     getStyleNow()
     {
       const millisPerDay = 86400000;
@@ -43,8 +44,8 @@ export default {
       return {
         top: bounds.top + 'px',
         height: bounds.height + 'px',
-        left: bounds.left + '%',
-        width: (100 - bounds.left) + '%',
+        left: 100 / details.concurrentCount * details.concurrentOffset + '%',
+        width: 100 / details.concurrentCount + '%',
         backgroundColor: stateColor,
         marginLeft: calendarEvent.starting ? 0 : '-5px',
         marginRight: calendarEvent.ending ? 0 : '-5px',

--- a/store/splus.js
+++ b/store/splus.js
@@ -104,6 +104,13 @@ export const getters = {
       .scale([colors.lightBlue.darken4, colors.cyan.darken4])
       .colors(uniqueIds.length);
 
+    const lecturesByStart = new Map();
+    const lectureStartKey = (lecture) => `${lecture.day} ${lecture.begin}`;
+    state.lectures[state.week].forEach((lecture) =>
+      lecturesByStart.set(lectureStartKey(lecture), [...
+        (lecturesByStart.get(lectureStartKey(lecture)) || []),
+        lecture]));
+
     return state.lectures[state.week].map((lecture) => {
       const start = moment(lecture.start);
       const color = colorScale[uniqueIds.indexOf(lecture.lecturerId)];
@@ -129,6 +136,10 @@ export const getters = {
           color, // needs to be a hex string
           description: `\n${lecture.lecturer}\n${lecture.room} ${lecture.info}`,
           location: lecture.room,
+          concurrentCount: lecturesByStart.get(lectureStartKey(lecture))
+            .length,
+          concurrentOffset: lecturesByStart.get(lectureStartKey(lecture))
+            .indexOf(lecture),
         },
         schedule: {
           on: shiftedStart,


### PR DESCRIPTION
Sieht so aus:
<img src=https://user-images.githubusercontent.com/15379000/48961683-dbf13e80-ef76-11e8-988c-9ac0190af20c.png height=300 />

Die Erkennung von gleichzeitigen Events funktioniert anhand von den Startzeitpunkten. Wie man sieht, überlappen sich zwei Events, die sich umschließen. Ebenso überlappen sich Events, die kurz hintereinander starten.
Das ist aber nicht trivial zu lösen. Ein Fall: A umschließt B und C, jetzt müssten B und C auf eine Seite kommen und alle drei 50% der Breite haben. Dafür muss man wahrscheinlich eine Art Layoutmanager schreiben…
Wenn man anhand des Starts vergleicht, kann man aber den Titel lesen, deswegen ist das erst einmal gut genug.