### PR TITLE
Scale production pm2 services to all cores

### DIFF
--- a/process-prod.yml
+++ b/process-prod.yml
@@ -2,7 +2,7 @@ apps:
     - name: api-prod
       port: 3002
       script: ./dist/server/server.js
-      instances: 1
+      instances: 'max'
       watch: true
       ignore_watch: ['./api-cache/**', './node_modules/**']
       exec_mode: cluster
@@ -13,7 +13,7 @@ apps:
       port: 3001
       script: ./node_modules/nuxt/bin/nuxt-start
       cwd: ./
-      instances: 1
+      instances: 'max'
       watch: true
       ignore_watch: ['./api-cache/**', './node_modules/**']
       exec_mode: cluster


### PR DESCRIPTION
Pro CPU-Kern wird jeweils ein Prozess für den API & Nuxt server gestartet. pm2 macht automatisches load balancing.

Dokumentation dazu: https://pm2.io/doc/en/runtime/guide/load-balancing/