### PR TITLE
Fix custom schedule duplicating lectures

### DIFF
--- a/store/splus.js
+++ b/store/splus.js
@@ -198,14 +198,22 @@ export const mutations = {
   /**
    * Add given lectures to the state,
    * paying respect to currently active whitelist.
+   * Deduplicate using the title ID.
    */
   setLectures(state, { lectures, week }) {
+    // filter based on whitelist
     const whitelist = state.schedule.whitelist;
     const filteredLectures = !!whitelist ? lectures.filter(
       (lecture1) => whitelist.includes(lecture1.titleId)) : lectures;
 
+    // filter duplicates
+    const lecturesByTitle = new Map();
+    filteredLectures.forEach(
+      (lecture) => lecturesByTitle.set(lecture.titleId, lecture));
+    const uniqueLectures = [...lecturesByTitle.values()];
+
     // reactive variant of state.lectures[week].push(lectures)
-    Vue.set(state.lectures, week, filteredLectures);
+    Vue.set(state.lectures, week, uniqueLectures);
   },
   clearLectures(state) {
     state.lectures = {};


### PR DESCRIPTION
As reported by @BrainConverter, wenn ein personalisierter Kalender mehrere sich überschneidenden Basen hat, wurden die Vorlesungen doppelt angezeigt.

before
<img src=https://user-images.githubusercontent.com/15379000/48980125-2680d100-f0c5-11e8-955c-db3df7affc2d.jpeg height=300 />

after
<img src=https://user-images.githubusercontent.com/15379000/48980133-38627400-f0c5-11e8-9984-70d03b58a8bd.png height=300 />