### PR TITLE
Load whole month into custom schedule dialog

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -169,8 +169,15 @@ export default {
       const week = moment().isoWeek();
 
       try {
-        const response = await this.$axios.get(`/api/splus/${schedule.id}/${week}`);
-        this.$set(this.lectures, schedule.id, response.data);
+        const responses = [
+          await this.$axios.get(`/api/splus/${schedule.id}/${week}`),
+          await this.$axios.get(`/api/splus/${schedule.id}/${week+1}`),
+          await this.$axios.get(`/api/splus/${schedule.id}/${week+2}`),
+          await this.$axios.get(`/api/splus/${schedule.id}/${week+3}`),
+        ];
+        const uniqueLectures = flatten(responses.map(({ data }) => data))
+          .filter((lecture, index, self) => self.indexOf(lecture) == index);
+        this.$set(this.lectures, schedule.id, uniqueLectures);
       } catch (error) {
         this.setError('API-Verbindung fehlgeschlagen');
         console.error('error during API call', error.message);


### PR DESCRIPTION
Motivation:
Der Dialog für den personalisierten Kalender zeigt nur Vorlesungen der aktuellen Woche an. Manche VL laufen aber zweiwöchentlich oder unregelmäßig und können nicht ausgewählt werden.

Änderung:
Lade diese und die nächsten 3 Wochen. Das Semester geht nur noch 4 Wochen, deswegen reicht das ab morgen. 💩 
Das ist nicht ganz so schlimm, wie es aussieht, weil es nur wenige Kilobytes sind und im Browser und auf dem Server gecached wird.
Für nächstes Semester können wir dann eine bessere Lösung finden 😁 