### PR TITLE
Ask for consent for Matomo cookies

### DIFF
--- a/components/__tests__/spluseins-cookie-snackbar.spec.ts
+++ b/components/__tests__/spluseins-cookie-snackbar.spec.ts
@@ -15,17 +15,21 @@ Vue.use(Vuex);
 describe('Cookie snackbar', () => {
   let store;
 
-  function mountWithState(allowCookies) {
+  function mountWithState(allowAllCookies, allowNecessaryCookies) {
     const mutations = {
-      setCookiesAllowed: jest.fn(),
-      setCookiesDenied: jest.fn(),
+      setNecessaryCookiesAllowed: jest.fn(),
+      setAllCookiesAllowed: jest.fn(),
+      setAllCookiesDenied: jest.fn(),
     };
 
     store = new Vuex.Store({
       modules: {
         browserStateReady: true,
         privacy: {
-          state: { allowCookies, },
+          state: {
+            allowAllCookies,
+            allowNecessaryCookies,
+          },
           mutations: PrivacyModule.mutations,
           namespaced: true,
         }
@@ -36,24 +40,31 @@ describe('Cookie snackbar', () => {
   }
 
   it('should render a snackbar by default', () => {
-    const wrapper = mountWithState(undefined);
+    const wrapper = mountWithState(undefined, undefined);
     expect(wrapper.contains('.v-snack')).toBeTruthy();
   });
 
   it('should not render a snackbar when consent was given or denied', () => {
-    let wrapper = mountWithState(true);
+    let wrapper = mountWithState(true, true);
     expect(wrapper.contains('.v-snack')).toBeFalsy();
-    wrapper = mountWithState(false);
+    wrapper = mountWithState(false, false);
     expect(wrapper.contains('.v-snack')).toBeFalsy();
   });
 
   it('should mutate state after giving or denying consent', async () => {
-    let wrapper = mountWithState(undefined);
-    wrapper.find({ ref: 'btn-allow' }).trigger('click');
-    expect(store.state.privacy.allowCookies).toBe(true);
+    let wrapper = mountWithState(undefined, undefined);
+    wrapper.find({ ref: 'btn-allow-all' }).trigger('click');
+    expect(store.state.privacy.allowNecessaryCookies).toBe(true);
+    expect(store.state.privacy.allowAllCookies).toBe(true);
 
-    wrapper = mountWithState(undefined);
+    wrapper = mountWithState(undefined, undefined);
+    wrapper.find({ ref: 'btn-allow-necessary' }).trigger('click');
+    expect(store.state.privacy.allowNecessaryCookies).toBe(true);
+    expect(store.state.privacy.allowAllCookies).toBe(false);
+
+    wrapper = mountWithState(undefined, undefined);
     wrapper.find({ ref: 'btn-deny' }).trigger('click');
-    expect(store.state.privacy.allowCookies).toBe(false);
+    expect(store.state.privacy.allowNecessaryCookies).toBe(false);
+    expect(store.state.privacy.allowAllCookies).toBe(false);
   });
 });

--- a/components/spluseins-cookie-snackbar.vue
+++ b/components/spluseins-cookie-snackbar.vue
@@ -50,9 +50,15 @@ export default {
   },
   watch: {
     allowAllCookies() {
-      if (this.browserStateReady && this.allowAllCookies == false) {
-        this.$matomo.disableCookies();
-        this.$matomo.deleteCookies();
+      if (this.browserStateReady) {
+        if (this.allowAllCookies == false) {
+          this.$matomo.disableCookies();
+          this.$matomo.deleteCookies();
+          this.$matomo.setConsentGiven();
+        }
+        if (this.allowAllCookies == true) {
+          this.$matomo.rememberConsentGiven();
+        }
       }
     },
   },

--- a/components/spluseins-cookie-snackbar.vue
+++ b/components/spluseins-cookie-snackbar.vue
@@ -2,25 +2,33 @@
   <v-snackbar
     :value="snackbarOpen"
     :timeout="0"
+    vertical
     right>
-    Einstellungen im Browser speichern?
+    Cookies für Einstellungen und Analytics erlauben?
     <v-layout
-      justify-end
+      justify-space-between
       fluid
       row>
       <v-btn
         ref="btn-deny"
         flat
         icon
-        @click="setCookiesDenied()">
-        Nein
+        @click="setAllCookiesDenied()">
+        Nichts
       </v-btn>
       <v-btn
-        ref="btn-allow"
+        ref="btn-allow-necessary"
+        flat
+        icon
+        @click="setNecessaryCookiesAllowed()">
+        Einstellungen
+      </v-btn>
+      <v-btn
+        ref="btn-allow-all"
         color="success"
         flat
-        @click="setCookiesAllowed()">
-        Erlauben
+        @click="setAllCookiesAllowed()">
+        Einverstanden
       </v-btn>
     </v-layout>
   </v-snackbar>
@@ -33,17 +41,26 @@ export default {
   name: 'SpluseinsCookieSnackbar',
   computed: {
     snackbarOpen() {
-      return this.browserStateReady && this.allowCookies == undefined;
+      return this.browserStateReady && this.allowAllCookies == undefined;
     },
     ...mapState({
-      allowCookies: (state) => state.privacy.allowCookies,
+      allowAllCookies: (state) => state.privacy.allowAllCookies,
       browserStateReady: (state) => state.browserStateReady,
     }),
   },
+  watch: {
+    allowAllCookies() {
+      if (this.browserStateReady && this.allowAllCookies == false) {
+        this.$matomo.disableCookies();
+        this.$matomo.deleteCookies();
+      }
+    },
+  },
   methods: {
     ...mapMutations({
-      setCookiesAllowed: 'privacy/setCookiesAllowed',
-      setCookiesDenied: 'privacy/setCookiesDenied',
+      setNecessaryCookiesAllowed: 'privacy/setNecessaryCookiesAllowed',
+      setAllCookiesAllowed: 'privacy/setAllCookiesAllowed',
+      setAllCookiesDenied: 'privacy/setAllCookiesDenied',
     }),
   },
 };

--- a/plugins/vue-matomo.js
+++ b/plugins/vue-matomo.js
@@ -7,7 +7,7 @@ export default ({app}, inject) =>{
     siteId: 1,
     router: app.$router,
     enableLinkTracking: true,
-    requireConsent: false,
+    requireConsent: true,
     trackInitialView: true,
     trackerFileName: 'piwik',
   });

--- a/plugins/vue-matomo.js
+++ b/plugins/vue-matomo.js
@@ -1,14 +1,14 @@
-import Vue from 'vue'
-import VueMatomo from 'vue-matomo'
+import Vue from 'vue';
+import VueMatomo from 'vue-matomo';
 
 export default ({app}, inject) =>{
-    Vue.use(VueMatomo, {
-        host: 'https://analytics.spluseins.de',
-        siteId: 1,
-        router: app.$router,
-        enableLinkTracking: true,
-        requireConsent: false,
-        trackInitialView: true,
-        trackerFileName: 'piwik',
-    });
+  Vue.use(VueMatomo, {
+    host: 'https://analytics.spluseins.de',
+    siteId: 1,
+    router: app.$router,
+    enableLinkTracking: true,
+    requireConsent: false,
+    trackInitialView: true,
+    trackerFileName: 'piwik',
+  });
 };

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -3,7 +3,7 @@ import VuexPersistence from 'vuex-persist';
 export default ({ store }) => {
   window.onNuxtReady(() => new VuexPersistence({
     key: 'spluseins',
-    saveState: (key, state, storage) => !state.privacy.allowCookies ? undefined:
+    saveState: (key, state, storage) => !state.privacy.allowNecessaryCookies ? undefined:
       // pass through (https://github.com/championswimmer/vuex-persist/blob/master/src/index.ts#L211)
       storage.setItem(key, JSON.stringify(state)),
     restoreState: (key, storage) => {
@@ -23,7 +23,8 @@ export default ({ store }) => {
         favoriteSchedules: state.splus.favoriteSchedules,
       },
       privacy: {
-        allowCookies: state.privacy.allowCookies,
+        allowAllCookies: state.privacy.allowAllCookies,
+        allowNecessaryCookies: state.privacy.allowNecessaryCookies,
       },
     }),
   }).plugin(store));

--- a/store/privacy.js
+++ b/store/privacy.js
@@ -3,14 +3,21 @@ export const state = () => ({
    * May store cookies.
    * 3 state boolean™.
    */
-  allowCookies: undefined,
+  allowAllCookies: undefined,
+  allowNecessaryCookies: undefined,
 });
 
 export const mutations = {
-  setCookiesAllowed(state) {
-    state.allowCookies = true;
+  setAllCookiesAllowed(state) {
+    state.allowAllCookies = true;
+    state.allowNecessaryCookies = true;
   },
-  setCookiesDenied(state) {
-    state.allowCookies = false;
+  setNecessaryCookiesAllowed(state) {
+    state.allowAllCookies = false;
+    state.allowNecessaryCookies = true;
+  },
+  setAllCookiesDenied(state) {
+    state.allowAllCookies = false;
+    state.allowNecessaryCookies = false;
   },
 };


### PR DESCRIPTION
Änderung: Ersetze den Inhalt der Cookie-Snackbar durch die Optionen "Nichts / Einstellungen / Erlauben". Deaktiviere und lösche Matomo-Cookies für die ersten beiden Optionen. Matomo funktioniert auch ohne Cookies.

Hier ist nochmal die API-Dokumentation für Matomo: https://developer.matomo.org/api-reference/tracking-javascript

Das ist jetzt nach diesem Ratgeber gehalten, der sagt, dass Tracking grundsätzlich okay ist, weil wir die Daten nicht verarbeiten (lassen), sondern nur für uns nutzen: http://www.rechtzweinull.de/archives/2553-ist-tracking-nach-25-mai-2018-nur-noch-mit-einwilligung-bewertung-der-stellungnahme-der-datenschutzbehoerden-zu-tracking-targeting-co.html