### PR TITLE
Move schedules to /plan, make name a query param

### DIFF
--- a/components/custom-timetables-list.vue
+++ b/components/custom-timetables-list.vue
@@ -8,12 +8,12 @@
 
     <v-list-tile
       v-for="route in customSchedulesAsRoutes"
-      :key="route.params.schedule"
+      :key="route.query.name"
       :to="route"
       nuxt>
       <v-list-tile-content
         @click="trackMatomoEvent('Menu','custom plan used')">
-        <v-list-tile-title>{{ route.params.schedule }}</v-list-tile-title>
+        <v-list-tile-title>{{ route.query.name }}</v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
 

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -35,7 +35,7 @@
             :to="scheduleToRoute(schedule)"
             :key="schedule.id"
             nuxt>
-            <v-list-tile-content 
+            <v-list-tile-content
               value="true"
               @click="trackMatomoEvent('Menu','normal plan used', schedule.degreeShort + ' ' + schedule.label + ' ' + schedule.semester + '. Sem.')">
               <v-list-tile-title value="true">{{ schedule.label }}</v-list-tile-title>
@@ -77,7 +77,7 @@ export default {
     },
     scheduleToRoute(schedule) {
       return {
-        name: 'schedule',
+        name: 'plan-schedule',
         params: { schedule: schedule.id },
       };
     },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -89,6 +89,6 @@ export default {
   */
   generate: {
     fallback: true,
-    routes: schedules.map(({ id }) => `/${id}`),
+    routes: schedules.map(({ id }) => `/plan/${id}`),
   },
 };

--- a/pages/plan/_schedule.vue
+++ b/pages/plan/_schedule.vue
@@ -7,8 +7,8 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
-import SpluseinsCalendar from '../components/spluseins-calendar.vue';
+import { mapState, mapGetters } from 'vuex';
+import SpluseinsCalendar from '../../components/spluseins-calendar.vue';
 
 export default {
   name: 'SchedulePage',
@@ -21,6 +21,9 @@ export default {
     SpluseinsCalendar,
   },
   computed: {
+    ...mapGetters({
+      isCustomSchedule: 'splus/isCustomSchedule',
+    }),
     ...mapState({
       currentSchedule: (state) => state.splus.schedule,
     })
@@ -38,6 +41,6 @@ export default {
       console.log('lazy loading is enabled: not fetching any lectures');
     }
   },
-  watchQuery: ['id', 'course'], // rerender page when query params change
+  watchQuery: ['id', 'name', 'course'], // rerender page when query params change
 };
 </script>

--- a/store/splus.js
+++ b/store/splus.js
@@ -19,16 +19,14 @@ const isoWeek0 = moment()
 
 
 export function customScheduleToRoute(customSchedule) {
-  const params = {
-    schedule: customSchedule.label,
-  };
   const query = {
     id: customSchedule.id,
     course: customSchedule.whitelist,
+    name: customSchedule.label,
     v: 1
   };
 
-  return { name: 'schedule', params, query };
+  return { name: 'plan-schedule', params: {}, query };
 }
 
 export function shortenScheduleDegree(schedule) {
@@ -325,7 +323,7 @@ export const actions = {
           query.id : [query.id];
         const customSchedule = {
           id: ids,
-          label: params.schedule,
+          label: query.name,
           whitelist: courses,
         };
 


### PR DESCRIPTION
Ersetze den URL-Parameter für den Namen durch einen Query-Parameter, damit in Matomo der Query gefiltert werden kann.
Bewege alle Seiten nach /plan, um Konflikte mit neuen Seiten zu verhindern.
Macht bestehende Lesezeichen kaputt.