### PR TITLE
Add edit button to regular schedules, track buttons, fix xs layout

### DIFF
--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -6,7 +6,7 @@
       <v-layout
         justify-space-between
         row>
-        <v-flex>
+        <v-flex shrink>
           <v-tooltip
             v-bind="{setToday, todayDate, calendar}"
             name="today"

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -7,7 +7,7 @@
 
     <template slot="actions">
       <v-btn
-        v-if="!isFavorite"
+        v-if="!isCustomSchedule && !isFavorite"
         v-show="!isTinyMobile"
         :small="$vuetify.breakpoint.xs"
         icon
@@ -16,7 +16,7 @@
         <v-icon>favorite_border</v-icon>
       </v-btn>
       <v-btn
-        v-else
+        v-if="!isCustomSchedule && isFavorite"
         v-show="!isTinyMobile"
         :small="$vuetify.breakpoint.xs"
         icon
@@ -40,14 +40,16 @@
         <v-list>
           <v-list-tile
             v-show="isTinyMobile"
+            v-if="!isCustomSchedule"
             @click="isFavorite? removeFavoriteSchedule(currentSchedule) : addFavoriteSchedule(currentSchedule);
                     isFavorite? trackMatomoEvent('Calendar','removeFavorites') : trackMatomoEvent('Calendar','addToFavorites')">
             <v-list-tile-content>
-              <v-list-tile-title v-if="isFavorite">Favorisieren</v-list-tile-title>
+              <v-list-tile-title v-if="!isFavorite">Favorisieren</v-list-tile-title>
               <v-list-tile-title v-else>Favorit entfernen</v-list-tile-title>
             </v-list-tile-content>
           </v-list-tile>
-          <v-list-tile @click="editTimetableDialogOpen = true; trackMatomoEvent('Calendar', isCustomSchedule ? 'clickEditCustomSchedule' : 'clickEditSchedule')">
+          <v-list-tile
+            @click="editTimetableDialogOpen = true; trackMatomoEvent('Calendar', isCustomSchedule ? 'clickEditCustomSchedule' : 'clickEditSchedule')">
             <v-list-tile-content>
               <v-list-tile-title v-if="isCustomSchedule">Bearbeiten</v-list-tile-title>
               <v-list-tile-title v-else>Personalisieren</v-list-tile-title>
@@ -62,6 +64,7 @@
       </v-menu>
 
       <v-btn
+        v-if="isCustomSchedule"
         v-show="!isMobile"
         outline
         @click="deleteTimetableDialogOpen = true; trackMatomoEvent('Calendar', 'clickDeleteCustomSchedule')">


### PR DESCRIPTION
Änderungen:
* "Favorite" auf sehr kleinen Displays (iPhone 5, Galaxy S5) in das Dreipunktemenü verschoben
* Matomo für Bearbeiten & Löschen-Button hinzugefügt (ungetestet)
* Der Bearbeiten-Knopf wird als "Personalisieren" an normalen Plänen angezeigt