### PR TITLE
Fix broken favorites route

### DIFF
--- a/components/favorite-timetables-list.vue
+++ b/components/favorite-timetables-list.vue
@@ -5,7 +5,7 @@
     <v-subheader>
       Favoriten
     </v-subheader>
-      
+
     <v-list-tile
       v-for="schedule in favoriteSchedules"
       :to="scheduleToRoute(schedule)"
@@ -16,14 +16,15 @@
         <v-list-tile-title>{{ schedule.degreeShort }} {{ schedule.label }} - {{ schedule.semester }}. Sem.</v-list-tile-title>
       </v-list-tile-content>
     </v-list-tile>
-  
+
   </v-list>
 
 </template>
 
 <script lang="js">
   import { mapState } from 'vuex';
-  
+  import { scheduleToRoute } from '../store/splus';
+
   export default  {
     name: 'FavoriteTimetablesList',
     computed: {
@@ -35,12 +36,7 @@
       trackMatomoEvent(category, action, name) {
         this.$matomo.trackEvent(category, action, name);
       },
-      scheduleToRoute(schedule) {
-        return {
-          name: 'schedule',
-          params: { schedule: schedule.id },
-        };
-      },
+      scheduleToRoute,
     }
-}
+};
 </script>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -63,6 +63,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { scheduleToRoute } from '../store/splus';
 
 export default {
   name: 'GeneralTimetablesList',
@@ -75,12 +76,7 @@ export default {
     trackMatomoEvent(category, action, name) {
       this.$matomo.trackEvent(category, action, name);
     },
-    scheduleToRoute(schedule) {
-      return {
-        name: 'plan-schedule',
-        params: { schedule: schedule.id },
-      };
-    },
+    scheduleToRoute,
   }
 };
 </script>

--- a/store/splus.js
+++ b/store/splus.js
@@ -29,6 +29,13 @@ export function customScheduleToRoute(customSchedule) {
   return { name: 'plan-schedule', params: {}, query };
 }
 
+export function scheduleToRoute(schedule) {
+  return {
+    name: 'plan-schedule',
+    params: { schedule: schedule.id },
+  };
+}
+    
 export function shortenScheduleDegree(schedule) {
   let shortenedDegree
   switch(schedule.degree){


### PR DESCRIPTION
In #101 habe ich vergessen, die `scheduleToRoute` der favorites mit anzupassen. Beim Klicken eines Favorits gab es einen Fehler.

Die Funktion habe ich in den store bewegt, weil sie von general timetables und favorite timetables verwendet worden ist.

Langfristig sollten wir solche utility-Funktionen (`scheduleToRoute`, `uniq`, …) aus dem store in eine Bibliothek bewegen, weil sie mit dem store selbst nichts zu tun haben.