### PR TITLE
Fix too many api requests

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -173,7 +173,6 @@ export default {
       const week = moment().isoWeek();
 
       try {
-        console.log('im here loading shit')
         const responses = [
           await this.$axios.get(`/api/splus/${schedule.id}/${week}`),
           await this.$axios.get(`/api/splus/${schedule.id}/${week+1}`),

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -142,9 +142,13 @@ export default {
       getScheduleById: 'splus/getScheduleById',
     }),
   },
-  mounted() {
-    if (!this.isNew) {
-      this.load();
+  watch: {
+    dialogOpen() {
+      if(this.dialogOpen){
+        if (!this.isNew) {
+          this.load();
+        }
+      }
     }
   },
   methods: {
@@ -169,6 +173,7 @@ export default {
       const week = moment().isoWeek();
 
       try {
+        console.log('im here loading shit')
         const responses = [
           await this.$axios.get(`/api/splus/${schedule.id}/${week}`),
           await this.$axios.get(`/api/splus/${schedule.id}/${week+1}`),


### PR DESCRIPTION
Der Custom Timetable Dialog ist in jedem Plan eingebunden. In ihm wurden in mounted() schon alle Pläne der nächsten Wochen vorgeladen. Jetzt wird darauf gewartete, dass der Dialog geöffnet wird und erst dann wird geladen.