### PR TITLE
Remove title of custom plan in page header

### DIFF
--- a/pages/plan/_schedule.vue
+++ b/pages/plan/_schedule.vue
@@ -14,7 +14,7 @@ export default {
   name: 'SchedulePage',
   head() {
     return {
-      title: "Personlisierter Plan",
+      title: 'Personlisierter Plan',
     };
   },
   components: {

--- a/pages/plan/_schedule.vue
+++ b/pages/plan/_schedule.vue
@@ -14,7 +14,7 @@ export default {
   name: 'SchedulePage',
   head() {
     return {
-      title: this.currentSchedule.label,
+      title: "Personlisierter Plan",
     };
   },
   components: {


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/38299190/49275639-30675300-f47c-11e8-98be-0d543dafe401.png)

Habe Matomo so konfigueriert, dass der Parameter "name" in der URL nicht auftaucht, jedoch steht der Name des personalisierten Plans noch im Page Header.