### PR TITLE
Basic Event Dialog

### DIFF
--- a/assets/ds-de.js
+++ b/assets/ds-de.js
@@ -123,9 +123,10 @@ export default {
       }
     },
     dsCalendarEventPopover: {
+      allowEditOnReadOnly: false,
       formats: {
-        start:    'dddd, MMMM D',
-        time:     'h:mm a'
+        start:    'dddd, D. MMMM',
+        time:     'hh:mm'
       },
       labels: {
         allDay:   'All day',

--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -730,6 +730,10 @@ export default {
 
 <style lang="scss">
 
+.ds-ev-description{
+  display: none;
+}
+
 .ds-calendar-event{
   user-select: auto !important;
 }
@@ -837,9 +841,6 @@ export default {
 
 .ds-week .ds-day-today > div:not(.ds-hour):not(.v-menu) {
   border-top: 3px solid var(--v-primary-base) !important;
-}
-.ds-ev-description{
-  white-space: pre-wrap;
 }
 
 </style>

--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -730,10 +730,6 @@ export default {
 
 <style lang="scss">
 
-.ds-calendar-event .v-menu__activator * {
-  cursor: text;
-}
-
 .ds-calendar-event{
   user-select: auto !important;
 }

--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -95,6 +95,14 @@
       </span>
     </template>
 
+    <template 
+      slot="eventPopover" 
+      slot-scope="slotData">
+      <ds-calendar-event-popover
+        v-bind="slotData"
+        :read-only="true"/>
+    </template>
+
   </dayspan-custom-calendar>
 </template>
 

--- a/plugins/dayspan.config.js
+++ b/plugins/dayspan.config.js
@@ -53,5 +53,10 @@ export default {
         textDecorationColor: cancelled ? stateColor : 'inherit'
       };
     },
+
+    getEventOccurrence()
+    {    
+      return "";
+    },
   },
 };

--- a/store/splus.js
+++ b/store/splus.js
@@ -136,7 +136,7 @@ export const getters = {
         data: {
           title: lecture.title,
           color, // needs to be a hex string
-          description: `\n${lecture.lecturer}`,
+          description: `\n${lecture.lecturer}, \n${lecture.info}`,
           location: lecture.room,
           concurrentCount: lecturesByStart.get(lectureStartKey(lecture))
             .length,

--- a/store/splus.js
+++ b/store/splus.js
@@ -136,7 +136,7 @@ export const getters = {
         data: {
           title: lecture.title,
           color, // needs to be a hex string
-          description: `\n${lecture.lecturer}\n${lecture.room} ${lecture.info}`,
+          description: `\n${lecture.lecturer}`,
           location: lecture.room,
           concurrentCount: lecturesByStart.get(lectureStartKey(lecture))
             .length,

--- a/store/splus.js
+++ b/store/splus.js
@@ -136,7 +136,7 @@ export const getters = {
         data: {
           title: lecture.title,
           color, // needs to be a hex string
-          description: `\n${lecture.lecturer}, \n${lecture.info}`,
+          description: lecture.info ? `\n${lecture.lecturer}, \n${lecture.info}` : `\n${lecture.lecturer}`,
           location: lecture.room,
           concurrentCount: lecturesByStart.get(lectureStartKey(lecture))
             .length,


### PR DESCRIPTION
Wenn man auf ein Event clickt wird nun der dayspan event Dialog angezeigt.

In diesem sieht man nun den Raum und die Info, dafür wird im Event selbst nur noch der Titel angezeigt.

TODO für nächste PRs:
- Zeit in den Dialog einbinden, dazu muss inder dayspan.config.js die Methode getEventOccurences überarbeitet werden, also die Verschiebung der Events wieder "herausgerechnet" werden
- Eventtitel umbrechen