### PR TITLE
Add API support for setplan

### DIFF
--- a/assets/schedules.json
+++ b/assets/schedules.json
@@ -656,4 +656,12 @@
   "faculty": "Elektrotechnik",
   "degree": "Master of Engineering",
   "semester": 1
+}, {
+  "id": "SPLUS5A5760",
+  "slug": "R WR 1",
+  "label": "Wirtschaftsrecht",
+  "faculty": "Recht",
+  "degree": "Bachelor of Laws",
+  "semester": 1,
+  "setplan": true
 } ]

--- a/server/lib/SplusApi.ts
+++ b/server/lib/SplusApi.ts
@@ -3,12 +3,13 @@ import {SplusParser} from './SplusParser';
 import {ILecture} from './ILecture';
 
 export class SplusApi {
-    private static _base_uri = 'http://splus.ostfalia.de/semesterplan123.php';
+    private static _plan_base_uri = 'http://splus.ostfalia.de/semesterplan123.php';
+    private static _set_base_uri  = 'http://splus.ostfalia.de/studentensetplan123.php';
 
-    private static splusRequest(identifier: string, weekOfYear: number): PromiseLike<string> {
+    private static splusPlanRequest(identifier: string, weekOfYear: number): PromiseLike<string> {
         return request({
             method: 'POST',
-            uri: this._base_uri,
+            uri: this._plan_base_uri,
             qs: { identifier, },
             formData: {
                 weeks: weekOfYear.toString(),
@@ -16,8 +17,19 @@ export class SplusApi {
         });
     }
 
-    static async getData(identifier: string, weekOfYear: number): Promise<ILecture[]> {
-        const data = await this.splusRequest(identifier, weekOfYear);
+    private static splusSetRequest(identifier: string, weekOfYear: number): PromiseLike<string> {
+        return request({
+            method: 'POST',
+            uri: this._set_base_uri,
+            formData: {
+                'identifier[]': identifier,
+                weeks: weekOfYear.toString(),
+            },
+        });
+    }
+
+    static async getData(identifier: string, weekOfYear: number, isSet: boolean): Promise<ILecture[]> {
+        const data = isSet? await this.splusSetRequest(identifier, weekOfYear) : await this.splusPlanRequest(identifier, weekOfYear);
         const lectures = new SplusParser(data).getLectures();
         return lectures;
     }

--- a/store/splus.ts
+++ b/store/splus.ts
@@ -40,12 +40,14 @@ export function scheduleToRoute(schedule): Partial<Route> {
 export function shortenScheduleDegree(schedule): string {
   let shortenedDegree
   switch(schedule.degree){
-    case "Bachelor of Science": shortenedDegree = "B.Sc."; break;
-    case "Master of Science": shortenedDegree = "M.Sc."; break;
-    case "Bachelor of Arts": shortenedDegree = "B.A."; break;
-    case "Master of Arts": shortenedDegree = "M.A."; break;
-    case "Bachelor of Engineering": shortenedDegree = "B.Eng."; break;
-    case "Master of Engineering": shortenedDegree = "M.Eng."; break;
+    case 'Bachelor of Science': shortenedDegree = 'B.Sc.'; break;
+    case 'Master of Science': shortenedDegree = 'M.Sc.'; break;
+    case 'Bachelor of Arts': shortenedDegree = 'B.A.'; break;
+    case 'Master of Arts': shortenedDegree = 'M.A.'; break;
+    case 'Bachelor of Engineering': shortenedDegree = 'B.Eng.'; break;
+    case 'Master of Engineering': shortenedDegree = 'M.Eng.'; break;
+    case 'Bachelor of Laws': shortenedDegree = 'LL.B.'; break;
+    case 'Master of Laws': shortenedDegree = 'LL.M.'; break;
     default: shortenedDegree = schedule.degree;
   }
 


### PR DESCRIPTION
Änderungen:
 * Für an die API geschickte IDs wird entschieden, ob sie zu einem setplan gehört.
 * Der API-Wrapper schickt den entsprechenden Request.
 * Wenn eine ID nicht in der Timetables-JSON existiert, wird 404 zurückgeliefert, statt dass ein request gegen splus geschickt wird.
 * `schedule` zu `timetable` umbenannt und `"` durch `'` ersetzt.