### PR TITLE
Nuxt generate: Do not prebuild schedules

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,3 @@
-const schedules = require('./assets/schedules.json');
-
 export default {
   mode: 'universal',
 
@@ -97,6 +95,6 @@ export default {
   */
   generate: {
     fallback: true,
-    routes: schedules.map(({ id }) => `/plan/${id}`),
+    routes: [],
   },
 };


### PR DESCRIPTION
Ich habe herausgefunden, dass der statische build von dynamisch generierten URLs wegen #101 wieder funktioniert, ohne dass man die routes in der Konfiguration angibt. Vor #101 war das nötig, weil die Netlify-Seiten sonst 404 waren.
Das Entfernen beschleunigt den statischen build und ist hoffentlich ein workaround für die Ressourcenprobleme, die in #137 durch das Hinzufügen von noch mehr Plänen entstanden sind.