### PR TITLE
Calendar: Optimize for desktop

### DIFF
--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -830,4 +830,9 @@ export default {
 .ds-hour-list :nth-child(8) .ds-hour-text {
   display: none !important; /* hide 07:00 because it would be cut off */
 }
+
+.ds-hour {
+  /* same as plugins/dayspan.config.js */
+  height: 50px !important;
+}
 </style>

--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -835,4 +835,8 @@ export default {
   /* same as plugins/dayspan.config.js */
   height: 50px !important;
 }
+
+.ds-week-view-scrollable {
+  height: 650px !important; /* TODO magic number */
+}
 </style>

--- a/plugins/dayspan.config.js
+++ b/plugins/dayspan.config.js
@@ -5,7 +5,9 @@ const dayspanOffsetHoursPre = 7; // schedule starts at 7 (instead of 0)
 const dayspanOffsetHoursPost = 4; // schedule ends at 20 (instead of 24)
 const dayspanDayLengthHours = Constants.HOURS_IN_DAY - dayspanOffsetHoursPre - dayspanOffsetHoursPost;
 const dayspanScalingFactor = Constants.HOURS_IN_DAY / dayspanDayLengthHours;
-const hourHeight = 40;
+// 13*50px = 650px, +300px for toolbars and footer, +100px for browser = a bit less than 1080px total
+// same as components/dayspan-custom-calendar .ds-hour styles
+const hourHeight = 50;
 
 // see: https://github.com/ClickerMonkey/dayspan-vuetify/blob/master/src/component.js
 


### PR DESCRIPTION
wie in #148 angefragt
hängt von #150 ab

Erhöhe die Höhe der Stunden im Kalender von 40px auf 50px, damit auf 1920x1080 die Seite komplett ausgefüllt wird. Unseren Analytics nach ist das die häufigste höchste Bildschirmhöhe 📈 
Sieht das gut aus?