### PR TITLE
Calendar: Fix wrong week/year transition

### DIFF
--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -215,7 +215,12 @@ export default {
       this.$matomo.trackEvent(category, action);
     },
     calendarChanged({ calendar }) {
-      this.setWeek(calendar.start.date.isoWeek());
+      if (calendar.start.date.year() == 2019) {
+        // TODO FIXME
+        this.setWeek(calendar.start.date.isoWeek() + 52);
+      } else {
+        this.setWeek(calendar.start.date.isoWeek());
+      }
     },
     routeToRoot() {
       this.$router.replace('/');


### PR DESCRIPTION
Wenn man im Kalender nach vorne scrollt, landet man bei Woche 1. Man sieht zum Beispiel die Prüfungstermine nicht.
Mit diesem workaround sollte es erst einmal gehen.