### PR TITLE
Timetables Maschinenbau: Fix duplicate

### DIFF
--- a/assets/timetables.json
+++ b/assets/timetables.json
@@ -841,7 +841,7 @@
   "semester": 1,
   "setplan": true
 }, {
-  "id": "SPLUSBF0E2A",
+  "id": "SPLUSBF0E2B",
   "slug": "M-BM1c",
   "label": "Maschinenbau c",
   "faculty": "Maschinenbau",


### PR DESCRIPTION
Die ID ist die gleiche wie im Block darüber gewesen (M-BM1b), nuxt gibt bei doppelten Listen-IDs in der `general-timetables-list` eine Warnung oder einen Fehler aus.