### PR TITLE
Custom timetable: Preload weeks 10 to 14

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -185,12 +185,9 @@ export default {
       const week = moment().isoWeek();
 
       try {
-        const responses = [
-          await this.$axios.get(`/api/splus/${schedule.id}/${week}`),
-          await this.$axios.get(`/api/splus/${schedule.id}/${week+1}`),
-          await this.$axios.get(`/api/splus/${schedule.id}/${week+2}`),
-          await this.$axios.get(`/api/splus/${schedule.id}/${week+3}`),
-        ];
+        // TODO update this in WS19/20 or at start of SS19
+        const responses = await Promise.all([10, 11, 12, 13, 14].map((week) =>
+          this.$axios.get(`/api/splus/${schedule.id}/${week}`)));
         const uniqueLectures = flatten(responses.map(({ data }) => data))
           .filter((lecture, index, self) => self.indexOf(lecture) == index);
         this.$set(this.lectures, schedule.id, uniqueLectures);


### PR DESCRIPTION
Weil die Vorlesungen, die in der "personalisierter Plan"-Liste angezeigt werden, vom aktuellen Datum + 3 Wochen geladen werden, kann man jetzt, einen Monat vor Beginn des Semesters, noch nichts auswählen.

Um das Problem zu umgehen, habe ich die 5 ersten Wochen des SS19 hartkodiert. 💩 