### PR TITLE
Set a sensible default week

### DIFF
--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -129,20 +129,10 @@ export default {
     DayspanCustomEventPopover,
   },
   data() {
-    const stateWeek = this.$store.state.splus.week;
-    const isStateWeekSet = stateWeek != undefined;
-    const startOfWeek = moment().startOf('isoWeek');
-
-    if (isStateWeekSet) {
-      startOfWeek.isoWeek(stateWeek);
-    } else {
-      // if the user is looking at today and is on Sat/Sun, peek to the next week
-      if (moment().day() == 6 || moment().day() == 0) {
-        startOfWeek.add(1, 'weeks');
-      }
-    }
-
-    const around = Day.fromMoment(startOfWeek);
+    const week = moment()
+      .isoWeek(this.$store.getters['splus/weekOrDefault'])
+      .startOf('isoWeek');
+    const around = Day.fromMoment(week);
     const weeklyCalendar = {
       id: 'W',
       label: 'Woche',

--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -104,7 +104,7 @@ export default {
     load(){
       console.log("load")
       this.setSchedule(this.subscribedTimetable);
-      this.resetWeek();
+      this.resetWeek(true);
       this.clearLectures();
       this.loadLectures();
     }

--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -102,7 +102,6 @@ export default {
       return {event: possibleEvents[0] != undefined? possibleEvents[0] : undefined, ready: events.length != 0 };
     },
     load(){
-      console.log("load")
       this.setSchedule(this.subscribedTimetable);
       this.resetWeek(true);
       this.clearLectures();

--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -30,6 +30,9 @@ export default {
 
     if (process.static) {
       store.commit('enableLazyLoad');
+      store.commit('splus/resetWeek', true);
+    } else {
+      store.commit('splus/resetWeek', false);
     }
 
     if (process.client || !store.state.lazyLoad) {


### PR DESCRIPTION
In #168 habe ich `resetWeek` entfernt und übersehen, dass damit beim ersten Laden die Daten für die Woche `undefined` abgerufen werden und mit #161 hat sich ein Konflikt ergeben, weil dort `resetWeek` aufgerufen wird.

Jetzt ist es wieder drin, aber besser als vorher:
* Sa/So wird die nächste Woche gewählt und die Logik liegt jetzt im Store statt in dem Kalender
* beim Wechseln des Kalenders gibt es keinen reset
* jetzt geht es bestimmt im statischen build auch
* bis zu Semesterbeginn SS19 ist die erste Woche Standard