### PR TITLE
Timetable: Update title

### DIFF
--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -14,7 +14,7 @@ export default {
   name: 'TimetablePage',
   head() {
     return {
-      title: 'Personalisierter Plan',
+      title: 'Stundenplan',
     };
   },
   components: {


### PR DESCRIPTION
Wenn man einen Plan aus der Liste auswählt, hat man keinen "Personalisierten Plan" ausgewählt, aber so steht es im Dokumententitel, das hat mich gestört