### PR TITLE
UI Changes + matomo event fix

### DIFF
--- a/components/copy-text-dialog.vue
+++ b/components/copy-text-dialog.vue
@@ -69,7 +69,7 @@ export default {
 <style scoped lang="scss">
 
 .card-text{
-  padding-bottom: 0; 
+  padding: 10px 10px 0px 10px; 
 }
 
 </style> 

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -38,7 +38,7 @@
             nuxt>
             <v-list-tile-content
               value="true"
-              @click="trackMatomoEvent('Menu','normal plan used', schedule.degreeShort + ' ' + schedule.label + ' ' + schedule.semester + '. Sem.')">
+              @click="trackMatomoEvent('Menu','normal plan used', schedule.description)">
               <v-list-tile-title value="true">{{ schedule.label }}</v-list-tile-title>
             </v-list-tile-content>
           </v-list-tile>

--- a/components/last-changes-card.vue
+++ b/components/last-changes-card.vue
@@ -5,8 +5,11 @@
     </v-card-title>
     <v-card-text class="card-text-padding">
       <ul>
-        <li>Auf der Startseite werden die wichtigsten Informationen in einem Dashboard zusammengefasst.</li>
-        <li>Der Essensplan der Mensa Wolfenbüttel wird angezeigt.</li>
+        <li>Der (vorläufige) Stundenplan für das Sommersemester 2019 kann abgerufen werden.</li>
+        <li>Auf der Startseite wird die nächste Vorlesung eines abbonierten Planes angzeigt.</li>
+        <li>Jeder Benutzer kann sich personalisierte Pläne aus verschiedenen Stundenplänen zusammenstellen.</li>
+        <li>Durch Anklicken der Veranstaltungen in einem Stundenplan können weitere Informationen abgerufen werden.</li>
+        <li>Der Mensaplan für Wolfenbüttel kann abgerufen werden</li>
         <li>SplusEins kann auf Smartphones mit einem modernen Browser als App installiert werden.</li>
       </ul>
     </v-card-text>

--- a/components/last-changes-card.vue
+++ b/components/last-changes-card.vue
@@ -7,9 +7,9 @@
       <ul>
         <li>Der (vorläufige) Stundenplan für das Sommersemester 2019 kann abgerufen werden.</li>
         <li>Auf der Startseite wird die nächste Vorlesung eines abbonierten Planes angzeigt.</li>
-        <li>Jeder Benutzer kann sich personalisierte Pläne aus verschiedenen Stundenplänen zusammenstellen.</li>
+        <li>Jeder Benutzer kann sich personalisierte Pläne aus verschiedenen Stundenplänen zusammenstellen und teilen.</li>
         <li>Durch Anklicken der Veranstaltungen in einem Stundenplan können weitere Informationen abgerufen werden.</li>
-        <li>Der Mensaplan für Wolfenbüttel kann abgerufen werden</li>
+        <li>Der Mensaplan für Wolfenbüttel kann abgerufen werden.</li>
         <li>SplusEins kann auf Smartphones mit einem modernen Browser als App installiert werden.</li>
       </ul>
     </v-card-text>

--- a/components/mensa-card.vue
+++ b/components/mensa-card.vue
@@ -9,7 +9,7 @@
         :key="item.id"
         dense>
         <div class="list-tile">
-          <span class="category">{{ item.category }}:</span>
+          <b>{{ item.category }}:</b>
           <br>
           <span>{{ item.name }}</span>
           <br>
@@ -66,10 +66,6 @@ export default {
 
 .list-tile{
   padding: 5px 0 5px 0px;
-}
-
-.category {
-  font-weight: bold;
 }
 
 .card-text-padding{

--- a/components/spluseins-about.vue
+++ b/components/spluseins-about.vue
@@ -18,7 +18,7 @@
           SplusEins
         </v-card-title>
 
-        <v-card-text>
+        <v-card-text class="text-padding">
           <p>
             Ein inoffizieller Stundenplan von Studenten für Studenten der Ostfalia-Hochschule.<br>
             Gebaut mit <a href="https://nuxtjs.org">Nuxt</a>, <a href="https://vuetifyjs.com">Vuetify</a>, <a href="https://github.com/ClickerMonkey/dayspan-vuetify">Dayspan-Vuetify</a>, Icons von <a href="https://materialdesignicons.com/">Material Design Icons</a> und der Schriftart <a href="https://fonts.google.com/specimen/Roboto">Roboto</a>.<br>
@@ -41,8 +41,8 @@
             target="_blank"
             href="https://github.com/SplusEins/SplusEins">
             <v-icon
-              medium
-              color="black">mdi-github-circle</v-icon>
+              :color="isDark? 'white': 'black'"
+              medium>mdi-github-circle</v-icon>
           </v-btn>
           <v-btn
             flat
@@ -60,6 +60,7 @@
 
 
 <script>
+import { mapState } from 'vuex';
 
 export default {
   name: 'SpluseinsAbout',
@@ -68,6 +69,11 @@ export default {
       active: false,
     };
   },
+  computed: {
+    ...mapState({
+      isDark: (state) => state.ui.isDark,
+    }),
+  },
   methods:{
     trackMatomoEvent (category, action , name) {
       this.$matomo.trackEvent(category, action, name);
@@ -75,3 +81,9 @@ export default {
   }
 };
 </script>
+
+<style scoped lang="scss">
+.text-padding{
+  padding: 10px 16px 0px 16px;
+}
+</style>

--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -1,18 +1,18 @@
 <template>
 
   <v-card>
-    <v-card-title>
+    <v-card-title class="title-padding">
       <span class="headline">Nächste Vorlesungen</span>
       <v-btn
         v-show="hasSubscribableTimetables"
         icon
         @click="subscribeDialogOpen = true">
-        <v-icon>mdi-bookmark</v-icon>
+        <v-icon>mdi-bookmark-outline</v-icon>
       </v-btn>
     </v-card-title>
 
     <v-card-text v-if="nextEvent != undefined">
-      {{ nextEvent.data.title }} {{ nextEvent.data.description }}
+      <b>{{ nextEvent.data.title }} {{ nextEvent.data.description }}</b>
       <br>
       Datum: {{ nextEvent.schedule.on.format('dddd, DD.MM.YYYY') }}
       <br>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,20 +17,21 @@
       </v-flex>
 
       <v-flex
+        v-show="mensaIsOpen"
+        xs12
+        md6
+        lg4
+        d-flex>
+        <mensa-card />
+      </v-flex>
+
+      <v-flex
         v-if="false"
         xs12
         md6
         lg4
         d-flex>
         <news-card />
-      </v-flex>
-
-      <v-flex
-        xs12
-        md6
-        lg4
-        d-flex>
-        <upcoming-lectures-card />
       </v-flex>
 
       <v-flex
@@ -41,15 +42,15 @@
         d-flex>
         <quick-access-card />
       </v-flex>
-      
+
       <v-flex
-        v-show="mensaIsOpen"
         xs12
         md6
         lg4
         d-flex>
-        <mensa-card />
+        <upcoming-lectures-card />
       </v-flex>
+      
     </v-layout>
   </v-container>
 </template>


### PR DESCRIPTION
Ein paar Sachen welche mit gestört hatten:
- im About Dialog hat ein padding gefehlt und das GitHub Icon war im DarkTheme schlecht erkennbar
- im Copy-Dialog hat ein padding gefehlt
- die last-changes-card war veraltet
- die Anordnung der Cards im Dashboard hat mir nicht so gut gefallen
- das Icon der upcoming-lectures-card war zu dominant, es ist nun nicht mehr gefüllt sonder hat nur noch ein Outline