### PR TITLE
Fix mensa card display

### DIFF
--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -2,7 +2,7 @@
 
   <v-card>
     <v-card-title class="title-padding">
-      <span class="headline">Nächste Vorlesungen</span>
+      <span class="headline">Nächste Vorlesung</span>
       <v-btn
         v-show="hasSubscribableTimetables"
         icon

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
       </v-flex>
 
       <v-flex
-        v-show="mensaIsOpen"
+        v-if="mensaIsOpen"
         xs12
         md6
         lg4


### PR DESCRIPTION
Im Master wird heute (Samstag) im Dashboard die Mensa-Card angezeigt, obwohl sie heute nicht geöffenet hat. Nutzt man v-if statts v-show funktioniert es. Das liegt daran, dass die verwendete Direktive d-flex genau wie v-show die CSS-Property "display" verändert und dann v-show überschreibt. 😆 
Könnte man die Reihenfolge der Direktiven ändern, würde es sicher gehen, aber das erlaubt CheckStyle nicht.