### PR TITLE
Add Ostfalia news API endpoint

### DIFF
--- a/server/App.ts
+++ b/server/App.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import splusController from './controllers/splus';
 import mensaController from './controllers/mensa';
+import newsController from './controllers/news';
 
 class App {
   public app: express.Application;
@@ -13,6 +14,7 @@ class App {
   private routes(): void {
     this.app.use(this.basePath + '/splus', splusController);
     this.app.use(this.basePath + '/mensa', mensaController);
+    this.app.use(this.basePath + '/news', newsController);
   }
 }
 

--- a/server/controllers/mensa.ts
+++ b/server/controllers/mensa.ts
@@ -37,7 +37,7 @@ router.options('/', cors());
  * @return {date: number (acts also as id), data: {}}
  */
 router.get('/', cors(), async (req, res, next) => {
-  const key = moment().format('YYYY-MM-DD');
+  const key = 'mensa-' + moment().format('YYYY-MM-DD');
 
   try {
     const data = await cache.wrap(key, async () => {

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -1,0 +1,60 @@
+import * as express from 'express';
+import * as cors from 'cors';
+import * as cacheManager from 'cache-manager';
+import * as fsStore from 'cache-manager-fs-hash';
+import * as moment from 'moment';
+import * as cheerio from 'cheerio';
+
+const NEWS_CACHE_SECONDS = 1800;
+
+// default must be in /tmp because the rest is RO on AWS Lambda
+const CACHE_PATH = process.env.CACHE_PATH || '/tmp/spluseins-cache';
+const CACHE_DISABLE = !!process.env.CACHE_DISABLE;
+
+const axios = require('axios');
+const router = express.Router();
+const cache = CACHE_DISABLE ?
+  cacheManager.caching({ store: 'memory', max: 0 }) :
+  cacheManager.caching({
+    store: fsStore,
+    options: {
+      path: CACHE_PATH,
+      ttl: 60,
+      subdirs: true,
+    },
+  });
+
+/**
+ * Accept CORS preflight requests.
+ */
+router.options('/', cors());
+
+/**
+ * Get Ostfalia news
+ */
+router.get('/ostfalia', cors(), async (req, res, next) => {
+  const key = 'ostfalia-news-' + moment().format('YYYY-MM-DD');
+
+  try {
+    const data = await cache.wrap(key, async () => {
+      console.log(`ostfalia news cache miss for key ${key}`);
+
+      const response = await axios.get('https://www.ostfalia.de/cms/de');
+      const $ = cheerio.load(response.data);
+      return $('article.news-box').map(function(i, article) {
+        return {
+          title: $('a', this).text().trim(),
+          link: 'https://www.ostfalia.de' + $('a', this).attr('href'),
+          text: $('p', this).text().trim(),
+        };
+      }).get();
+    }, { ttl: NEWS_CACHE_SECONDS });
+
+    res.set('Cache-Control', `public, max-age=${NEWS_CACHE_SECONDS}`);
+    res.json(data);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;


### PR DESCRIPTION
Scraped die News-Box der ostfalia.de-Seite und macht die Artikeldaten über `/api/news/ostfalia` in folgendem Format zugänglich:
```json
[{
  "title":"Es sind noch Studienplätze frei!",
  "link":"https://www.ostfalia.de/cms/de/campus/detail/news/be1e550e-1eea-11e9-99a4-d96edd3be9f9",
  "text":"Wer sich beeilt, kann sich jetzt noch für das Sommersemester 2019 bewerben!"
}]
```

@BrainConverter go to town 🙂 