### PR TITLE
Custom Schedule Dialog Fixes

### DIFF
--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -46,6 +46,7 @@
             <v-flex xs12>
               <timetable-select
                 v-show="selectedSchedules.length <= maxSchedules"
+                :selected-schedules="selectedSchedules"
                 :loading="loading"
                 @input="addSchedule" />
             </v-flex>

--- a/components/custom-timetable-dialog.vue
+++ b/components/custom-timetable-dialog.vue
@@ -22,8 +22,8 @@
             :disabled="!valid"
             dark
             flat
-            @click.native="allowNecessaryCookies? save(): cookieReminderDialogOpen = true; 
-                           trackMatomoEvent('Menu','saveCustomTimetable',' Anzahl Pläne:',selectedSchedules.length ); 
+            @click.native="allowNecessaryCookies? save(): cookieReminderDialogOpen = true;
+                           trackMatomoEvent('Menu','saveCustomTimetable',' Anzahl Pläne:',selectedSchedules.length );
                            trackMatomoEvent('Menu','saveCustomTimetable','Anzahl Kurse:', selectedCourses.length)">
             Speichern</v-btn>
         </v-toolbar-items>
@@ -66,15 +66,14 @@
                 v-show="selectedSchedules.length > 0"
                 v-model="selectedCourses"
                 :max-courses="maxCourses"
-                :lectures="allLectures"
-                :loading="loading" />
+                :lectures="allLectures"/>
             </v-flex>
           </v-layout>
         </v-container>
       </v-form>
     </v-card>
 
-    <custom-timetable-cookie-reminder 
+    <custom-timetable-cookie-reminder
       v-model="cookieReminderDialogOpen"
       @continue="save()"/>
 
@@ -187,9 +186,10 @@ export default {
     removeSchedule(schedule) {
       const index = this.selectedSchedules.indexOf(schedule);
       this.selectedSchedules.splice(index, 1);
+      const titles = this.lectures[schedule.id].map(lecture => lecture.title)
       this.$set(this.lectures, schedule.id, []);
       this.selectedCourses = this.selectedCourses.filter(
-        (course) => course.id == schedule.id);
+         (course) => !titles.includes(course.title));
     },
     async loadLectures(schedule) {
       this.loading = true;

--- a/components/timetable-select.vue
+++ b/components/timetable-select.vue
@@ -32,7 +32,7 @@
     </v-flex>
     <v-flex align-self-center>
       <v-btn
-        :disabled="loading || selectedSchedule == undefined"
+        :disabled="disableLoad"
         :loading="loading"
         small
         round
@@ -54,6 +54,10 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    selectedSchedules: {
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -79,6 +83,9 @@ export default {
     },
     hasMultipleSchedules() {
       return this.schedules && this.schedules.length > 1;
+    },
+    disableLoad() {
+      return this.loading || this.selectedSchedule == undefined || this.selectedSchedules.includes(this.selectedSchedule);
     },
     ...mapGetters({
       schedulesTree: 'splus/getSchedulesAsTree',

--- a/components/timetable-select.vue
+++ b/components/timetable-select.vue
@@ -34,7 +34,6 @@
       <v-btn
         :disabled="disableLoad"
         :loading="loading"
-        small
         round
         depressed
         color="secondary"


### PR DESCRIPTION
- Wenn man einen geladenen Schedule gelöscht hat wurden alle selectedCourses statt nur die Kurse des gelöschten Schedules abgewählt.
- Der Button zum Laden eines Planes ist nun deaktiviert, wenn er bereits geladen ist.
- Der Button zum Laden eines Planes ist nun nicht mehr "small".