### PR TITLE
Fix CI

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -16,7 +16,7 @@ resources:
     type: git
     source:
       uri: https://github.com/spluseins/spluseins.git
-      branch: ci/node-v
+      branch: master
 
   - name: server-deploy-dev
     type: rsync-resource

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -16,7 +16,7 @@ resources:
     type: git
     source:
       uri: https://github.com/spluseins/spluseins.git
-      branch: master
+      branch: ci/node-v
 
   - name: server-deploy-dev
     type: rsync-resource

--- a/concourse/tests.yml
+++ b/concourse/tests.yml
@@ -1,7 +1,9 @@
 platform: linux
 image_resource:
   type: docker-image
-  source: {repository: node}
+  source: 
+    repository: node
+    tag: 11.10.1
 
 inputs:
   - name: build-result


### PR DESCRIPTION
https://stackoverflow.com/questions/55059748/travis-jest-typeerror-cannot-assign-to-read-only-property-symbolsymbol-tostr

In der neusten Node Version 11.11 gibt es einen Bug. Die Tests laufen nun mit einer älteren Node Version.