### PR TITLE
Add link to ICS in calendar action bar

### DIFF
--- a/components/calendar-action-bar.vue
+++ b/components/calendar-action-bar.vue
@@ -37,6 +37,11 @@
             <v-list-tile-title>Teilen</v-list-tile-title>
           </v-list-tile-content>
         </v-list-tile>
+        <v-list-tile :href="icsLink">
+          <v-list-tile-content>
+            <v-list-tile-title>Extern öffnen</v-list-tile-title>
+          </v-list-tile-content>
+        </v-list-tile>
         <v-list-tile
           @click="editTimetableDialogOpen = true; $track('Calendar', isCustomSchedule ? 'clickEditCustomSchedule' : 'clickEditSchedule')">
           <v-list-tile-content>
@@ -70,6 +75,12 @@
         :breakpoint="$vuetify.breakpoint.xl"
         icon="mdi-pencil"
         @click="editTimetableDialogOpen = true; $track('Calendar', isCustomSchedule ? 'clickEditCustomSchedule' : 'clickEditSchedule')" />
+      <responsive-icon-button
+        :breakpoint="$vuetify.breakpoint.xl"
+        :href="icsLink"
+        icon="mdi-calendar"
+        text="Extern öffnen"
+        @click="() => undefined" />
     </span>
 
     <custom-timetable-delete-dialog
@@ -117,6 +128,28 @@ export default {
     },
     isFavorite() {
       return this.favoriteSchedules.filter(favorite => favorite.id == this.currentSchedule.id).length != 0;
+    },
+    icsLink() {
+      let base = this.$axios.defaults.baseURL;
+      if (!base.startsWith('http')) {
+        base = window.location.origin + base;
+      }
+      base = base.replace(/^https?/i, 'webcal');
+
+      const path = 'api/ics/v1/';;
+      const timetable = this.currentSchedule;
+
+      let timetables;
+      let titleIds;
+      if (this.isCustomSchedule) {
+        timetables = this.currentSchedule.id.join(',');
+        titleIds = this.currentSchedule.whitelist.join(',');
+      } else {
+        timetables = this.currentSchedule.id;
+        titleIds = '';
+      }
+
+      return base + path + timetables + '/' + titleIds;
     },
     currentAsCustomSchedule() {
       if (this.isCustomSchedule) {

--- a/components/responsive-icon-button.vue
+++ b/components/responsive-icon-button.vue
@@ -7,6 +7,7 @@
       :outline="props.breakpoint"
       :icon="!props.breakpoint"
       :flat="!props.breakpoint"
+      :href="props.href"
       @click="listeners.click">
       <v-icon :left="props.breakpoint">{{ props.icon }}</v-icon>
       <span v-show="props.breakpoint">{{ props.text }}</span>
@@ -29,6 +30,11 @@ export default {
     },
     text: {
       required: true,
+      type: String
+    },
+    href: {
+      required: false,
+      default: undefined,
       type: String
     },
   },

--- a/components/responsive-icon-button.vue
+++ b/components/responsive-icon-button.vue
@@ -7,7 +7,6 @@
       :outline="props.breakpoint"
       :icon="!props.breakpoint"
       :flat="!props.breakpoint"
-      :href="props.href"
       @click="listeners.click">
       <v-icon :left="props.breakpoint">{{ props.icon }}</v-icon>
       <span v-show="props.breakpoint">{{ props.text }}</span>
@@ -30,11 +29,6 @@ export default {
     },
     text: {
       required: true,
-      type: String
-    },
-    href: {
-      required: false,
-      default: undefined,
       type: String
     },
   },

--- a/server/controllers/ics.ts
+++ b/server/controllers/ics.ts
@@ -52,6 +52,7 @@ router.get('/:version/:timetables/:lectures?', async (req, res, next) => {
     .filter((timetable) => timetable != undefined);
 
   if (timetables.length == 0) {
+    res.set('Cache-Control', `public, max-age=${ICS_CACHE_SECONDS}`);
     res.send(404);
     return;
   }

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -67,6 +67,7 @@ router.get('/ostfalia/:faculty', cors(), async (req, res, next) => {
   if (!['i', 'r', 'e', 'sz', 'wf', 'wob', 'sud'].includes(faculty)) {
     // Informatik, Recht, Elektrotechnik,
     // Salzgitter, Wolfenbüttel, Wolfsburg, Suderburg
+    res.set('Cache-Control', `public, max-age=${NEWS_CACHE_SECONDS}`);
     res.send(404);
     return;
   }

--- a/server/controllers/splus.ts
+++ b/server/controllers/splus.ts
@@ -24,6 +24,7 @@ router.get('/:timetable/:week', cors(), async (req, res, next) => {
   const timetableId = req.params.timetable;
   const timetable = TIMETABLES.find(({ id }) => id == timetableId);
   if (!timetable) {
+    res.set('Cache-Control', `public, max-age=${SPLUS_CACHE_SECONDS}`);
     res.send(404);
     return;
   }

--- a/store/splus.ts
+++ b/store/splus.ts
@@ -65,6 +65,9 @@ function defaultWeek() {
 }
 
 export const state = () => ({
+  /**
+   * Current schedule, either one of TIMETABLES or customSchedules.
+   */
   schedule: undefined,
   schedules: TIMETABLES.map(
     (timetable) => ({


### PR DESCRIPTION
Änderungen:
* Die Button-Zeile vom Kalender getrennt
* Der Titel-Filter ist in der ICS-API jetzt optional, standard ist "alle Vorlesungen"
* Die ICS-API gibt 404 zurück, wenn die übergebenen timetables nicht existieren
* Cache-Header für alle 404s von der API gesetzt
* Button zum Öffnen des ICS in Outlook, der Kalender-App oder anderen Anwendungen hinzugefügt

![subscribe-webcal](https://user-images.githubusercontent.com/15379000/54073242-380d7380-4285-11e9-8681-f1acc014665a.png)

Bitte mit verschiedenen Geräten und Anwendungen testen 🙂 