### PR TITLE
Fix sections calculation bug

### DIFF
--- a/components/stats-card.vue
+++ b/components/stats-card.vue
@@ -4,10 +4,11 @@
       <span class="headline">Statistik</span>
     </v-card-title>
     <vc-donut 
-      :sections="sections"
+      :sections="sections" 
       :size="250"
       :thickness="30"
       :background="isDark ? '#424242' : 'white'"
+      :total="totalHours"
       unit="px">
       <h1>{{ totalHours }}h</h1>diese Woche
     </vc-donut>
@@ -45,12 +46,15 @@ export default {
       this.updateSections();
     },
   },
+  mounted() {
+    this.updateSections(); 
+  },
   methods: {
     updateSections() {
        let uniqueLectures = new Map();
        let weekdays = [];
        this.sections = [];
-       this.totalHours = 0;
+       this.totalHours = 0; 
 
        this.upcomingLectures.forEach(element => {
          if(uniqueLectures.has(element.title)){
@@ -66,8 +70,9 @@ export default {
        uniqueLectures.forEach((value) => {
           this.totalHours += value
        });
+
        uniqueLectures.forEach((value, key) => {
-          this.sections.push({label: key + ' - ' + value + ' Stunden', value: value / this.totalHours *100});
+          this.sections.push({label: key + ' - ' + value + ' Stunden', value: value});
        });
     },
   },

--- a/components/stats-card.vue
+++ b/components/stats-card.vue
@@ -4,7 +4,7 @@
       <span class="headline">Statistik</span>
     </v-card-title>
     <vc-donut 
-      :sections="sections" 
+      :sections="sections"
       :size="250"
       :thickness="30"
       :background="isDark ? '#424242' : 'white'"
@@ -54,7 +54,7 @@ export default {
        let uniqueLectures = new Map();
        let weekdays = [];
        this.sections = [];
-       this.totalHours = 0; 
+       this.totalHours = 0;
 
        this.upcomingLectures.forEach(element => {
          if(uniqueLectures.has(element.title)){


### PR DESCRIPTION
https://deploy-preview-219--spluseins.netlify.com/plan?id=SPLUS7EEB0A&id=SPLUS087146&id=SPLUS087145&course=BKD&course=BuR&course=CM&course=D&course=MC3S&course=SEASEiK&course=SEAS&course=SSaCEASuS&course=UCK&course=URuA&course=WP&name=Mein%20Stundenplan&v=1

Vom Plugin wurde eine total-Wert der einzelnen Sections von 100.0000000001% errechnet was größer als der default total-Wert von 100% war.