### PR TITLE
News API: Get more Ostfalia news and add dates

### DIFF
--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -121,12 +121,11 @@ router.get('/ostfalia/:faculty', cors(), async (req, res, next) => {
       if (faculty == 'i') {
         return $('article .ostfalia-content table tbody td').map(function(i, td) {
           let link = $('a', this).first().attr('href');
-          if(!!link && !link.startsWith('http')){
+          if (!!link && !link.startsWith('http')) {
             link = 'https://www.ostfalia.de' + link;
-          }else{
+          } else {
             link = '';
           }
-        
 
           return {
             title: $(this).text().trim(),


### PR DESCRIPTION
Das News-Widget auf der Ostfalia-Seite schickt einen Request mit einigen Query-Parametern.
In der News-API wird eine vereinfachte Version abgespielt und das Ergebnis geparst.
Einen zusätzlichen Parameter `showDate` habe ich angeschaltet und damit hat die Ostfalia-News-API jetzt auch Zeitstempel.