### PR TITLE
Campus News: Truncate only after 50 chars

### DIFF
--- a/store/news.js
+++ b/store/news.js
@@ -46,7 +46,7 @@ export const actions = {
 
       const truncateArticle = (article) => {
         const sentences = article.text.split('.');
-        const text = sentences.length > 1 ? `${sentences[0]}.` : article.text;
+        const text = sentences.reduce((text, sentence) => text.length < 50 ? text + sentence + '.' : text, '');
         return {
           ...article,
           text,


### PR DESCRIPTION
"Dr. Max Muster gewinnt Preisausschreiben" wird fälschlicherweise zu "Dr.", also wird nach dem letzten Satz bei mehr als 50 Zeichen Textlänge erst abgeschnitten.