### PR TITLE
Use vuetify-loader

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -84,11 +84,6 @@ export default {
   ** Build configuration
   */
   build: {
-    parallel: true,
-    cache: false,
-    /*
-    ** You can extend webpack config here
-    */
     extend(config, ctx) {
       // Run ESLint on save
       if (ctx.isDev && ctx.isClient) {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,5 @@
 import * as META_INFORMATION from './assets/meta-information.json';
+import VuetifyLoaderPlugin from 'vuetify-loader/lib/plugin';
 
 export default {
   mode: 'universal',
@@ -98,7 +99,10 @@ export default {
           exclude: /(node_modules)/
         });
       }
-    }
+    },
+    plugins: [new VuetifyLoaderPlugin()],
+    extractCSS: true,
+    transpile: ['vuetify/lib'],
   },
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -15841,18 +15841,6 @@
         "postcss": "^7.0.0",
         "postcss-load-config": "^2.0.0",
         "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
       }
     },
     "postcss-logical": {
@@ -17278,7 +17266,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",


### PR DESCRIPTION
Motivation:
 * Mit vuetify-loader wird kein vuetify-CSS eingebunden, was nicht genutzt wird (siehe https://vuetifyjs.com/en/framework/a-la-carte#vuetify-loader). Das reduziert die Größe der CSS-Datei.
 * extractCSS zieht das CSS aus der index.html in eine seperate Datei. Das führt dazu, dass CSS und JavaScript gleichzeitig geparsed werden können und das erste Rendering schneller ist. Das macht Sinn, wenn man viel CSS hat.
 * Die dadurch aktivierte Abhängigkeit PostCSS in der Build-Kette scheint das parallele Bauen nicht zu unterstützen und wirft einen kryptischen Fehler.
 * postcss wurde nicht geladen. Nach einer Installation und anschließender Deinstallation des Pakets ging es wieder, vorsichtshalber habe ich die aktualisierte package-lock mit committed.