### PR TITLE
Hotfix title id collision

### DIFF
--- a/model/RichLecture.spec.ts
+++ b/model/RichLecture.spec.ts
@@ -53,6 +53,10 @@ describe('Test RichLecture', () => {
       'Elektr. u. magn. Felder',
       'Elektr. u. magn. Felder (online)',
     ]);
+    expectAllLecturesHaveDifferentTitleIds([
+      'IE-Wissensmanagement',
+      'ITM-Wirtschaftsrecht',
+    ]);
   });
 
   it('should generate the same title id for similar lectures', () => {

--- a/model/RichLecture.ts
+++ b/model/RichLecture.ts
@@ -18,8 +18,60 @@ export class RichLecture {
 
   private generateTitleId(title: string): string {
     switch (title) {
+      case 'IE-Wissensmanagement':
+        return 'IW';
       case 'ITM-Wirtschaftsrecht':
         return 'IW2';
+      case 'Betriebssysteme':
+        return 'B';
+      case 'Batteriesysteme':
+        return 'B2';
+      case 'BWL':
+        return 'B3';
+      case 'FDynReg':
+        return 'F1';
+      case 'FEM':
+        return 'F2';
+      case 'Festigkeitslehre':
+        return 'F3';
+      case 'Ingeniurmathematik':
+        return 'I1';
+      case 'Internetprotokolle':
+        return 'I2';
+      case 'KonstKunst':
+        return 'K1';
+      case 'KostGerKons':
+        return 'K2';
+      case 'MathePLUS':
+        return 'M1';
+      case 'MDyn':
+        return 'M2';
+      case 'MikroC':
+        return 'M3';
+      case 'Physik':
+        return 'P1';
+      case 'Projektmanagement':
+        return 'P2';
+      case 'Recht':
+        return 'R1';
+      case 'Regelungstechnik':
+        return 'R2';
+      case 'RegTechV':
+        return 'R3';
+      case 'Sachenrecht':
+        return 'S1';
+      case 'SchaltT':
+        return 'S2';
+      case 'SenMessDV':
+        return 'S3';
+      case 'Sim':
+        return 'S4';
+      case 'SteuerT':
+        return 'S5';
+      case 'Thermodynamik':
+        return 'T1';
+      case 'Tribologie':
+        return 'T2';
     }
     return (title.match(/\b(\w)/g) || []).join('');
   }

--- a/model/RichLecture.ts
+++ b/model/RichLecture.ts
@@ -17,6 +17,10 @@ export class RichLecture {
   duration: number;
 
   private generateTitleId(title: string): string {
+    switch (title) {
+      case 'ITM-Wirtschaftsrecht':
+        return 'IW2';
+    }
     return (title.match(/\b(\w)/g) || []).join('');
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,9 +1862,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
           "dev": true
         },
         "pretty-format": {
@@ -1924,9 +1924,9 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -2206,18 +2206,6 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
-          }
-        },
-        "handlebars": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-          "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
-          "dev": true,
-          "requires": {
-            "async": "^2.5.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
           }
         },
         "invert-kv": {
@@ -2672,9 +2660,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
           "dev": true
         },
         "pretty-format": {
@@ -12609,9 +12597,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
           "dev": true
         },
         "pkg-dir": {
@@ -16450,9 +16438,9 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prompts": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.3.tgz",
-      "integrity": "sha512-H8oWEoRZpybm6NV4to9/1limhttEo13xK62pNvn2JzY0MA03p7s0OjtmhXyon3uJmxiJJVSuUwEJFFssI3eBiQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+      "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.2",


### PR DESCRIPTION
'IE-Wissensmanagement' und 'ITM-Wirtschaftsrecht' werden die gleichen IDs zugeteilt, was Probleme verursacht. Um das Problem kurzfristig & rückwärtskompatibel zu lösen, habe ich eine Ausnahme hinzugefügt.