### PR TITLE
Use meta description template

### DIFF
--- a/assets/meta-information.json
+++ b/assets/meta-information.json
@@ -1,4 +1,0 @@
-{
-	"description" : "Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter",
-	"keywords": "Sommersemester 2019, SS19, Ostfalia, Stundenplan, Mensaplan, Mensa, Semesterplan, Plan, Wolfenbüttel, Salzgitter, Karl-Scharfenberg, Informatik, Maschinenbau, Soziale Arbeit, Elektrotechnik, Recht, Versorgungstechnik, Logistik, Informationsmanagement, Verkehr, Mediendesign, Medienmanagement, Personenverkehrsmanagement, Wahlfächer, Wahlpflichtfächer"
-}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,8 +9,16 @@ export default {
   head: {
     titleTemplate: '%s - SplusEins',
     meta: [
-      { hid: 'description', name: 'description', content: '%s – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter' },
-      { hid: 'og:description', name: 'og:description', content: '%s – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter' },
+      {
+        hid: 'description',
+        name: 'description',
+        template: (title) => `${title} – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter`,
+      },
+      {
+        hid: 'og:description',
+        property: 'og:description',
+        template: (title) => `${title} – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter`,
+      },
       { hid: 'keywords', name: 'keywords', content: 'Sommersemester 2019, SS19, Ostfalia, Stundenplan, Mensaplan, Mensa, Semesterplan, Plan, Wolfenbüttel, Salzgitter, Karl-Scharfenberg, Informatik, Maschinenbau, Soziale Arbeit, Elektrotechnik, Recht, Versorgungstechnik, Logistik, Informationsmanagement, Verkehr, Mediendesign, Medienmanagement, Personenverkehrsmanagement, Wahlfächer, Wahlpflichtfächer' },
     ],
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,3 @@
-import * as META_INFORMATION from './assets/meta-information.json';
 import VuetifyLoaderPlugin from 'vuetify-loader/lib/plugin';
 
 export default {
@@ -10,9 +9,9 @@ export default {
   head: {
     titleTemplate: '%s - SplusEins',
     meta: [
-      { hid: 'description', name: 'description', content: META_INFORMATION.description },
-      { hid: 'og:description', name: 'og:description', content: META_INFORMATION.description },
-      { hid: 'keywords', name: 'keywords', content: META_INFORMATION.keywords },
+      { hid: 'description', name: 'description', content: '%s – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter' },
+      { hid: 'og:description', name: 'og:description', content: '%s – Stundenplan und Mensaplan für Studenten der Ostfalia Wolfenbüttel und Salzgitter' },
+      { hid: 'keywords', name: 'keywords', content: 'Sommersemester 2019, SS19, Ostfalia, Stundenplan, Mensaplan, Mensa, Semesterplan, Plan, Wolfenbüttel, Salzgitter, Karl-Scharfenberg, Informatik, Maschinenbau, Soziale Arbeit, Elektrotechnik, Recht, Versorgungstechnik, Logistik, Informationsmanagement, Verkehr, Mediendesign, Medienmanagement, Personenverkehrsmanagement, Wahlfächer, Wahlpflichtfächer' },
     ],
   },
 

--- a/pages/datenschutz.vue
+++ b/pages/datenschutz.vue
@@ -111,17 +111,12 @@
 <script>
 import { mapMutations } from 'vuex';
 import PROTECTED_INFORMATION from '~/assets/protected-information.json';
-import META_INFORMATION from '~/assets/meta-information.json';
 
 export default {
   name: 'SpluseinsDataPrivacy',
   head() {
     return {
       title: 'Datenschutz',
-      meta: [
-        { hid: 'description', name: 'description', content: 'Datenschutz – ' + META_INFORMATION.description },
-        { hid: 'og:description', name: 'og:description', content: 'Datenschutz – ' + META_INFORMATION.description }
-      ],
     };
   },
   data() {

--- a/pages/datenschutz.vue
+++ b/pages/datenschutz.vue
@@ -117,6 +117,10 @@ export default {
   head() {
     return {
       title: 'Datenschutz',
+      meta: [
+        { hid: 'description', name: 'description', content: 'Datenschutz' },
+        { hid: 'og:description', property: 'og:description', content: 'Datenschutz' },
+      ],
     };
   },
   data() {

--- a/pages/impressum.vue
+++ b/pages/impressum.vue
@@ -54,17 +54,12 @@
 <script>
 import { mapMutations } from 'vuex';
 import PROTECTED_INFORMATION from '~/assets/protected-information.json';
-import META_INFORMATION from '~/assets/meta-information.json';
 
 export default {
   name: 'SpluseinsImpressum',
   head() {
     return {
       title: 'Impressum',
-      meta: [
-        { hid: 'description', name: 'description', content: 'Impressum – ' + META_INFORMATION.description },
-        { hid: 'og:description', name: 'og:description', content: 'Impressum – ' + META_INFORMATION.description }
-      ],
     };
   },
   data() {

--- a/pages/impressum.vue
+++ b/pages/impressum.vue
@@ -60,6 +60,10 @@ export default {
   head() {
     return {
       title: 'Impressum',
+      meta: [
+        { hid: 'description', name: 'description', content: 'Impressum' },
+        { hid: 'og:description', property: 'og:description', content: 'Impressum' },
+      ],
     };
   },
   data() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -217,6 +217,10 @@ export default {
   head() {
     return {
       title: 'Startseite',
+      meta: [
+        { hid: 'description', name: 'description', content: 'Startseite' },
+        { hid: 'og:description', property: 'og:description', content: 'Startseite' },
+      ],
     };
   },
   methods: {

--- a/pages/mensa.vue
+++ b/pages/mensa.vue
@@ -87,6 +87,10 @@ export default {
   head() {
     return {
       title: 'Mensaplan',
+      meta: [
+        { hid: 'description', name: 'description', content: 'Mensaplan' },
+        { hid: 'og:description', property: 'og:description', content: 'Mensaplan' },
+      ],
     };
   },
   computed: {

--- a/pages/mensa.vue
+++ b/pages/mensa.vue
@@ -79,7 +79,6 @@
 </template>
 
 <script>
-import META_INFORMATION from '~/assets/meta-information.json';
 import { mapState, mapActions, mapMutations } from 'vuex';
 import * as moment from 'moment';
 
@@ -88,10 +87,6 @@ export default {
   head() {
     return {
       title: 'Mensaplan',
-      meta: [
-        { hid: 'description', name: 'description', content: 'Mensaplan – ' + META_INFORMATION.description },
-        { hid: 'og:description', name: 'og:description', content: 'Mensaplan – ' + META_INFORMATION.description }
-      ],
     };
   },
   computed: {

--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -10,17 +10,12 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 import SpluseinsCalendar from '../../components/spluseins-calendar.vue';
-import META_INFORMATION from '~/assets/meta-information.json';
 
 export default {
   name: 'TimetablePage',
   head() {
     return {
-      title: 'Stundenplan',
-      meta: [
-        { hid: 'description', name: 'description', content: (this.schedule.description || this.schedule.label) + ' – ' + META_INFORMATION.description },
-        { hid: 'og:description', name: 'og:description', content: (this.schedule.description || this.schedule.label) + ' – ' + META_INFORMATION.description }
-      ],
+      title: this.isCustomSchedule ? 'Stundenplan' : (this.schedule.description || this.schedule.label),
     };
   },
   components: {

--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -16,6 +16,10 @@ export default {
   head() {
     return {
       title: this.isCustomSchedule ? 'Stundenplan' : this.schedule.longDescription,
+      meta: [
+        { hid: 'description', name: 'description', content: this.isCustomSchedule ? 'Stundenplan' : this.schedule.longDescription },
+        { hid: 'og:description', property: 'og:description', content: this.isCustomSchedule ? 'Stundenplan' : this.schedule.longDescription },
+      ],
     };
   },
   components: {

--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -15,7 +15,7 @@ export default {
   name: 'TimetablePage',
   head() {
     return {
-      title: this.isCustomSchedule ? 'Stundenplan' : (this.schedule.description || this.schedule.label),
+      title: this.isCustomSchedule ? 'Stundenplan' : this.schedule.longDescription,
     };
   },
   components: {

--- a/store/splus.js
+++ b/store/splus.js
@@ -32,6 +32,7 @@ export const state = () => ({
         params: { timetable: timetable.id },
       },
       description: `${shortenTimetableDegree(timetable)} ${timetable.label} - ${timetable.semester}. Sem.`,
+      longDescription: `${timetable.label} ${timetable.semester}. Semester ${shortenTimetableDegree(timetable)}`,
     })),
   /**
    * Map of created or visited custom timetables.


### PR DESCRIPTION
* Wie vorgeschlagen in #226, ersetze einzeln gesetzte Descriptions durch ein globales Template
* Setze den Dokumententitel für nicht personalisierte Pläne
* Benutze eine längere Beschreibung, um weniger Abkürzungen im Titel stehen zu haben - in umgekehrter Reihenfolge, um die wichtigste Information vorne stehen zu haben

Die description-Tags verschwinden immer noch bei einem Seitenwechsel.