### PR TITLE
Fix Matomo not tracking pageviews

### DIFF
--- a/plugins/vue-matomo.js
+++ b/plugins/vue-matomo.js
@@ -1,11 +1,11 @@
 import Vue from 'vue';
 import VueMatomo from 'vue-matomo';
 
-export default ({app}, inject) =>{
+export default ({ app }, inject) =>{
   Vue.use(VueMatomo, {
     host: 'https://analytics.spluseins.de',
     siteId: 1,
-    router: app.$router,
+    router: app.router,
     enableLinkTracking: true,
     requireConsent: true,
     trackInitialView: true,


### PR DESCRIPTION
`app.$router` gibt es nicht, also werden nach dem initial pageview keine pageviews getrackt 😮 