### PR TITLE
General timetables list: Reduce # of DOM nodes

### DIFF
--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -10,9 +10,7 @@
       no-action
     >
       <v-list-tile slot="activator">
-        <v-list-tile-content>
-          <v-list-tile-title>{{ path }}</v-list-tile-title>
-        </v-list-tile-content>
+        {{ path }}
       </v-list-tile>
 
       <lazy-hydrate
@@ -26,17 +24,9 @@
           sub-group
         >
           <v-list-tile slot="activator">
-            <v-list-tile-content>
-              <v-list-tile-title v-if="semester == 'WPF'">
-                Wahlpflichtfächer
-              </v-list-tile-title>
-              <v-list-tile-title v-else-if="semester == 'OTHER'">
-                Sonstiges
-              </v-list-tile-title>
-              <v-list-tile-title v-else>
-                {{ semester }}. Semester
-              </v-list-tile-title>
-            </v-list-tile-content>
+            {{ semester == 'WPF' ? 'Wahlpflichtfächer' : '' }}
+            {{ semester == 'OTHER' ? 'Sonstiges' : '' }}
+            {{ !['WPF', 'OTHER'].includes(semester) ? semester + '. Semester' : ''}}
           </v-list-tile>
 
           <v-list-tile
@@ -44,15 +34,9 @@
             :key="schedule.id"
             :to="schedule.route"
             nuxt
+            @click="$track('Calendar', 'sideMenu plan used', 'normal')"
           >
-            <v-list-tile-content
-              value="true"
-              @click="$track('Calendar', 'sideMenu plan used', 'normal')"
-            >
-              <v-list-tile-title value="true">
-                {{ schedule.label }}
-              </v-list-tile-title>
-            </v-list-tile-content>
+            {{ schedule.label }}
           </v-list-tile>
         </v-list-group>
 
@@ -61,15 +45,9 @@
           :key="semester"
           :to="schedules[0].route"
           nuxt
+          @click="$track('Calendar', 'sideMenu plan used', 'normal')"
         >
-          <v-list-tile-content>
-            <v-list-tile-title v-if="semester == 'WPF'">
-              Wahlpflichtfächer
-            </v-list-tile-title>
-            <v-list-tile-title v-else>
-              {{ semester }}. Semester
-            </v-list-tile-title>
-          </v-list-tile-content>
+          {{ semester == 'WPF' ? 'Wahlpflichtfächer' : semester + '. Semester' }}
         </v-list-tile>
       </lazy-hydrate>
     </v-list-group>
@@ -80,11 +58,11 @@
 import { mapGetters } from 'vuex';
 
 export default {
-name: 'GeneralTimetablesList',
-computed: {
-  ...mapGetters({
-    schedulesTree: 'splus/getSchedulesAsTree',
-  }),
-},
+  name: 'GeneralTimetablesList',
+  computed: {
+    ...mapGetters({
+      schedulesTree: 'splus/getSchedulesAsTree',
+    }),
+  },
 };
 </script>

--- a/components/general-timetables-list.vue
+++ b/components/general-timetables-list.vue
@@ -8,25 +8,23 @@
       v-for="(semesters, path) in schedulesTree"
       :key="path"
       no-action
+      @mouseover.native="$set(load, path, true)"
     >
       <v-list-tile slot="activator">
         {{ path }}
       </v-list-tile>
 
-      <lazy-hydrate
-        v-for="(schedules, semester) in semesters"
-        :key="path + semester"
-        when-visible
-      >
+      <template v-for="(schedules, semester) in semesters">
         <v-list-group
-          v-if="schedules.length > 1"
+          v-if="load[path] && schedules.length > 1"
+          :key="path + semester"
           no-action
           sub-group
         >
           <v-list-tile slot="activator">
             {{ semester == 'WPF' ? 'Wahlpflichtfächer' : '' }}
             {{ semester == 'OTHER' ? 'Sonstiges' : '' }}
-            {{ !['WPF', 'OTHER'].includes(semester) ? semester + '. Semester' : ''}}
+            {{ !['WPF', 'OTHER'].includes(semester) ? semester + '. Semester' : '' }}
           </v-list-tile>
 
           <v-list-tile
@@ -41,15 +39,15 @@
         </v-list-group>
 
         <v-list-tile
-          v-else
-          :key="semester"
+          v-if="load[path] && schedules.length == 1"
+          :key="path + semester"
           :to="schedules[0].route"
           nuxt
           @click="$track('Calendar', 'sideMenu plan used', 'normal')"
         >
           {{ semester == 'WPF' ? 'Wahlpflichtfächer' : semester + '. Semester' }}
         </v-list-tile>
-      </lazy-hydrate>
+      </template>
     </v-list-group>
   </v-list>
 </template>
@@ -59,6 +57,11 @@ import { mapGetters } from 'vuex';
 
 export default {
   name: 'GeneralTimetablesList',
+  data() {
+    return {
+      load: {},
+    };
+  },
   computed: {
     ...mapGetters({
       schedulesTree: 'splus/getSchedulesAsTree',


### PR DESCRIPTION
Reduziere die Anzahl HTML-Elemente von 6300 auf 5000 (20%) durch das Entfernen von nicht notwendiger Elemente in der general-timetables-list. Verbessert die Performance ein wenig.