### PR TITLE
Render dashboard only once

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,9 +24,10 @@
             <upcoming-lectures-card />
           </v-flex>
           <v-flex
+            v-show="$vuetify.breakpoint.mdAndUp"
             d-flex
           >
-            <faculty-news-card v-show="$vuetify.breakpoint.mdAndUp" />
+            <faculty-news-card />
           </v-flex>
         </v-layout>
       </v-flex>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,85 +10,12 @@
       row
       wrap
     >
-      <!-- Breakpoint xs and sm -->
-      <v-layout
-        v-show="$vuetify.breakpoint.xs || $vuetify.breakpoint.sm"
-        row
-        wrap
-      >
-        <v-flex
-          xs12
-          sm12
-          d-flex
-        >
-          <upcoming-lectures-card />
-        </v-flex>
-
-        <v-flex
-          v-show="displayMensaCard"
-          :d-flex="displayMensaCard"
-          xs12
-          sm12
-        >
-          <mensa-card />
-        </v-flex>
-
-        <v-flex
-          v-show="hasSubscribableTimetables"
-          :d-flex="hasSubscribableTimetables"
-          xs12
-          sm12
-        >
-          <quick-access-card />
-        </v-flex>
-
-        <v-flex
-          v-show="hasSubscribableTimetables"
-          :d-flex="hasSubscribableTimetables"
-          xs12
-          sm12
-        >
-          <stats-card />
-        </v-flex>
-
-        <v-flex
-          v-show="displayCampusNewsCard"
-          :d-flex="displayCampusNewsCard"
-          xs12
-          sm12
-        >
-          <campus-news-card />
-        </v-flex>
-
-        <v-flex
-          v-show="displayFacultyNewsCard"
-          :d-flex="displayFacultyNewsCard"
-          xs12
-          sm12
-        >
-          <faculty-news-card />
-        </v-flex>
-
-        <v-flex
-          d-flex
-          xs12
-          sm12
-        >
-          <last-changes-card />
-        </v-flex>
-      </v-layout>
-    </v-layout>
-
-    <!-- Breakpoint md and Up-->
-    <v-layout
-      v-show="$vuetify.breakpoint.mdAndUp"
-      row
-      wrap
-    >
       <v-flex
         d-flex
         md6
         lg6
+        order-xs1
+        order-md1
       >
         <v-layout column>
           <v-flex
@@ -99,7 +26,7 @@
           <v-flex
             d-flex
           >
-            <faculty-news-card />
+            <faculty-news-card v-show="$vuetify.breakpoint.mdAndUp" />
           </v-flex>
         </v-layout>
       </v-flex>
@@ -108,8 +35,18 @@
         d-flex
         md6
         lg6
+        order-xs5
+        order-md2
       >
         <campus-news-card />
+      </v-flex>
+
+      <v-flex
+        d-flex
+        order-xs6
+        order-md7
+      >
+        <faculty-news-card v-show="!$vuetify.breakpoint.mdAndUp" />
       </v-flex>
 
       <v-flex
@@ -118,6 +55,8 @@
         md6
         :lg4="hasSubscribableTimetables"
         :lg6="!hasSubscribableTimetables"
+        order-xs2
+        order-md3
       >
         <mensa-card />
       </v-flex>
@@ -127,6 +66,8 @@
         :d-flex="hasSubscribableTimetables"
         md6
         lg4
+        order-xs4
+        order-md4
       >
         <stats-card />
       </v-flex>
@@ -136,6 +77,8 @@
         :d-flex="hasSubscribableTimetables"
         md6
         lg4
+        order-xs3
+        order-md5
       >
         <quick-access-card />
       </v-flex>
@@ -146,6 +89,8 @@
         :lg4="!displayMensaCard && hasSubscribableTimetables"
         :lg6="displayMensaCard && !hasSubscribableTimetables"
         :lg12="displayMensaCard && hasSubscribableTimetables"
+        order-xs7
+        order-md6
       >
         <last-changes-card />
       </v-flex>


### PR DESCRIPTION
Mit den `order-xs1`-Attributen kann man die Reihenfolge der Elemente auf verschiedenen breakpoints definieren (https://vuetifyjs.com/en/framework/grid#unique-layouts).
Für die faculty-news-card funktioniert das nicht, weil sie verschachtelt ist.

Verbessert die Performance nur um 30ms auf meinem Laptop.