### PR TITLE
Create random splus session to prevent collisions

### DIFF
--- a/server/lib/SplusApi.ts
+++ b/server/lib/SplusApi.ts
@@ -26,6 +26,20 @@ const cache = CACHE_DISABLE ?
   });
 
 const flatten = <T>(arr: T[][]) => [].concat(...arr) as T[];
+const sessionKeyAlphabet = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Return a 26 character long random session ID, prefixed by 'spluseins-'.
+ * @see https://www.php.net/manual/en/function.session-create-id.php
+ */
+function createSessionId() {
+  let key = '';
+  for (let n = 0; n <= 16; n++) {
+    const pos = Math.floor(Math.random() * sessionKeyAlphabet.length);
+    key += sessionKeyAlphabet.charAt(pos);
+  }
+  return `spluseins-${key}`;
+}
 
 function splusPlanRequest(identifier: string, weekOfYear: number): Promise<string> {
   const url = new URL(PLAN_BASE);
@@ -33,9 +47,13 @@ function splusPlanRequest(identifier: string, weekOfYear: number): Promise<strin
   url.searchParams.append('identifier', identifier);
   const body = new URLSearchParams();
   body.append('weeks', weekOfYear.toString());
+  const sessionId = createSessionId();
 
   return fetch(url.toString(), {
     method: 'POST',
+    headers: {
+      'Cookie': `PHPSESSID=${sessionId}`,
+    },
     body,
   }).then((res) => res.text());
 }
@@ -46,9 +64,13 @@ function splusSetRequest(identifier: string, weekOfYear: number): Promise<string
   const body = new URLSearchParams();
   body.append('weeks', weekOfYear.toString());
   body.append('identifier[]', identifier);
+  const sessionId = createSessionId();
 
   return fetch(url.toString(), {
     method: 'POST',
+    headers: {
+      'Cookie': `PHPSESSID=${sessionId}`,
+    },
     body,
   }).then((res) => res.text());
 }


### PR DESCRIPTION
Bei parallelen Anfragen an splus wird nur eine Anfrage beantwortet.
Durch das Setzen einer zufälligen SessionID soll das umgangen werden.

Der Bug ist nur schwer reproduzierbar, deswegen konnte ich den Code auf den Fall nicht testen.