### PR TITLE
Remove unused moment js locales

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,5 @@
 import VuetifyLoaderPlugin from 'vuetify-loader/lib/plugin';
+import webpack from 'webpack';
 
 export default {
   mode: 'universal',
@@ -100,7 +101,10 @@ export default {
         });
       }
     },
-    plugins: [new VuetifyLoaderPlugin()],
+    plugins: [
+      new VuetifyLoaderPlugin(),
+      new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /de/),
+    ],
     extractCSS: true,
     transpile: ['vuetify/lib'],
   },


### PR DESCRIPTION
Reduziert die Größe der JavaScript-Dateien von 466kb auf 370kb (gzip-komprimiert) (20%)

Wir importieren moment js und dayspan auch. Ich habe nicht herausfinden können, warum deswegen die Bibliothek zwei mal eingebunden wird - an der Version liegt es nicht. Durch Deduplizierung könnte man noch einmal 17kb (gzip-komprimiert) sparen.