### PR TITLE
Use vuetify-loader correctly

### DIFF
--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify';
+import Vuetify from 'vuetify/lib';
 import moment from 'moment';
 import {default as options} from './dayspan.config.js'
 import DaySpanVuetify from 'dayspan-vuetify';


### PR DESCRIPTION
Reduziert die Build-Größe um 90kb (gzip-komprimiert) (20%).
Wir haben versehentlich alle vuetify-Komponenten zwei mal importiert. Die Zeile im a la carte - Guide (https://vuetifyjs.com/en/framework/a-la-carte#vuetify-loader) habe ich übersehen.