### PR TITLE
Fix responsive icon buttons missing imports

### DIFF
--- a/components/responsive-icon-button.vue
+++ b/components/responsive-icon-button.vue
@@ -8,7 +8,7 @@
       :outline="breakpoint"
       :icon="!breakpoint"
       :flat="!breakpoint"
-      @click="emit('click')"
+      @click="$emit('click')"
     >
       <v-icon :left="breakpoint">
         {{ icon }}

--- a/components/responsive-icon-button.vue
+++ b/components/responsive-icon-button.vue
@@ -22,8 +22,11 @@
 </template>
 
 <script>
+import { VBtn, VTooltip, VIcon } from 'vuetify/lib';
+
 export default {
   name: 'ResponsiveIconButton',
+  components: { VBtn, VTooltip, VIcon },
   props: {
     breakpoint: {
       required: true,

--- a/components/responsive-icon-button.vue
+++ b/components/responsive-icon-button.vue
@@ -1,32 +1,29 @@
-<template functional>
+<template>
   <v-tooltip
-    :disabled="props.breakpoint"
+    :disabled="breakpoint"
     bottom
   >
     <v-btn
       slot="activator"
-      :outline="props.breakpoint"
-      :icon="!props.breakpoint"
-      :flat="!props.breakpoint"
-      @click="listeners.click"
+      :outline="breakpoint"
+      :icon="!breakpoint"
+      :flat="!breakpoint"
+      @click="emit('click')"
     >
-      <v-icon :left="props.breakpoint">
-        {{ props.icon }}
+      <v-icon :left="breakpoint">
+        {{ icon }}
       </v-icon>
-      <span v-show="props.breakpoint">
-        {{ props.text }}
+      <span v-show="breakpoint">
+        {{ text }}
       </span>
     </v-btn>
-    <span>{{ props.text }}</span>
+    <span>{{ text }}</span>
   </v-tooltip>
 </template>
 
 <script>
-import { VBtn, VTooltip, VIcon } from 'vuetify/lib';
-
 export default {
   name: 'ResponsiveIconButton',
-  components: { VBtn, VTooltip, VIcon },
   props: {
     breakpoint: {
       required: true,

--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuetify from 'vuetify/lib';
+import Vuetify, { VMenu } from 'vuetify/lib';
 import moment from 'moment';
 import {default as options} from './dayspan.config.js'
 import DaySpanVuetify from 'dayspan-vuetify';
@@ -14,6 +14,7 @@ Vue.$dayspan.addLocale('de', LocaleDe);
 Vue.$dayspan.setLocale('de', true);
 
 Vue.use(Vuetify, {
+  components: { VMenu },
   iconfont: 'mdi',
   options: {
     customProperties: true,


### PR DESCRIPTION
Siehe https://vuetifyjs.com/en/framework/a-la-carte#functional-components, die imports können nicht automatisch festgestellt werden, wenn man functional components verwendet werden.