### PR TITLE
Course multiselect: Reduce table width on xs

### DIFF
--- a/components/course-multiselect.vue
+++ b/components/course-multiselect.vue
@@ -34,8 +34,13 @@
             hide-details
           />
         </td>
-        <td>{{ props.item.title }}</td>
-        <td>{{ props.item.lecturer }}</td>
+        <td>
+          {{ props.item.title }}
+          <span v-show="$vuetify.breakpoint.xs">({{ props.item.lecturerId }}, {{ props.item.room }})</span>
+        </td>
+        <td v-show="$vuetify.breakpoint.smAndUp">
+          {{ props.item.lecturer }}
+        </td>
         <td v-show="$vuetify.breakpoint.smAndUp">
           {{ props.item.room }}
         </td>


### PR DESCRIPTION
Schreibe alle Informationen in eine Spalte, um die Tabellenbreite auf xs zu reduzieren.
Auf iPhones sollte man die Tabelle jetzt normal scrollen können.