### PR TITLE
Course multiselect: Highlight conflicts

### DIFF
--- a/components/course-multiselect.vue
+++ b/components/course-multiselect.vue
@@ -4,7 +4,7 @@
       :value="overlappingCourses.length > 0"
       type="warning"
     >
-      Kurse überschneiden sich: {{ overlappingCourses }}
+      Kurse überschneiden sich: {{ overlappingCourses.join(', ') }}
     </v-alert>
     <v-data-table
       v-model="selectedCourses"
@@ -30,7 +30,7 @@
           <v-checkbox
             v-model="props.selected"
             :disabled="!props.selected && selectedCourses.length > maxCourses"
-            primary
+            :color="overlappingCourses.includes(props.item.title) ? 'warning' : 'secondary'"
             hide-details
           />
         </td>
@@ -130,7 +130,7 @@ export default {
       overlapLectures.forEach(
         (lecture) => overlapTitles.set(lecture.titleId, lecture.title));
 
-      return [...overlapTitles.values()].join(', ');
+      return [...overlapTitles.values()]
     },
   },
 };


### PR DESCRIPTION
Wenn ich auf meinem Smartphone die Liste der Kurse scrolle, kann ich nicht immer sehen, welche Kurse sich konkret überlappen.
Ich habe die Checkbox für Kurse mit Konflikt gelb gefärbt. Ist das intuitiv? Ich denke, dass sich die Bedeutung aus dem Kontext mit der gleichfarbigen Warnung ergibt und durch die Änderung der Farbe bei der Auswahl.

Alternativ könnte ich auch ein Icon anzeigen.

![Screenshot_2019-03-30 SplusEins](https://user-images.githubusercontent.com/15379000/55276971-299dff00-52fb-11e9-88f7-2c379a9e7b52.png)
