### PR TITLE
Cache middleware: Skip during static build

### DIFF
--- a/middleware/cached.js
+++ b/middleware/cached.js
@@ -1,7 +1,7 @@
 const PAGE_CACHE_SECONDS = process.env.PAGE_CACHE_SECONDS || '600';
 
 export default function ({ res, store }) {
-  if (process.server && store.state.errorQueue.length == 0) {
+  if (res != undefined && store.state.errorQueue.length == 0) {
     res.setHeader('Cache-Control', `public, max-age=${PAGE_CACHE_SECONDS}`);
   }
 }


### PR DESCRIPTION
Der Netlify-Build wirft einen Fehler (und macht nach ein paar Minuten trotzdem weiter), weil bei `nuxt generate` Middlewares keinen Zugriff auf `res` haben. Es können dann keine Cache-Header gesetzt werden.