### PR TITLE
Use vuetify a la carte css

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,7 +48,7 @@ export default {
   */
   css: [
     '~/assets/style/roboto.css',
-    'vuetify/dist/vuetify.min.css',
+    'vuetify/src/stylus/app.styl',
     'dayspan-vuetify/dist/lib/dayspan-vuetify.min.css',
     '@mdi/font/css/materialdesignicons.min.css'
   ],


### PR DESCRIPTION
Wir müssen nicht das ganze CSS importieren, sondern `vuetify-loader` sorgt dafür, dass nur das CSS für die tatsächlich verwendeten Komponenten geladen wird.

Steht so in der Dokumentation, habe ich in #269 überlesen.

Edit: In der Netlify-Preview sind es 60kb weniger im Vergleich zu master