### PR TITLE
Use nuxtServerInit to load data from API

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -147,19 +147,6 @@ export default {
       hasSubscribableTimetables: 'splus/hasSubscribableTimetables',
     }),
   },
-  async fetch({ store, params }) {
-    if (process.static) {
-      store.commit('enableLazyLoad');
-    }
-
-    if (process.client || !store.state.lazyLoad) {
-      await store.dispatch('mensa/load');
-      await store.dispatch('news/loadCampusNews');
-      await store.dispatch('news/loadFacultyNews');
-    } else {
-      console.log('lazy loading is enabled: not fetching mensa plan and timetable');
-    }
-  },
   head() {
     return {
       title: 'Startseite',

--- a/pages/mensa.vue
+++ b/pages/mensa.vue
@@ -100,17 +100,6 @@ export default {
       isDark: (state) => state.ui.isDark,
     }),
   },
-  async fetch({ store, params }) {
-    if (process.static) {
-      store.commit('enableLazyLoad');
-    }
-
-    if (process.client || !store.state.lazyLoad) {
-      await store.dispatch('mensa/load');
-    } else {
-      console.log('lazy loading is enabled: not fetching mensa plan');
-    }
-  },
   mounted() {
     if (this.lazyLoad) {
       // static build -> no mensa plan is in the store

--- a/pages/plan/_timetable.vue
+++ b/pages/plan/_timetable.vue
@@ -35,23 +35,15 @@ export default {
   },
   async fetch({ store, params, query, error }) {
     store.dispatch('splus/importSchedule', { params, query });
-
-    if (process.static) {
-      store.commit('enableLazyLoad');
-      store.commit('splus/resetWeek', true);
-    } else {
-      store.commit('splus/resetWeek', false);
-    }
+    store.commit('splus/resetWeek', process.static);
 
     if (store.state.splus.schedule == undefined) {
       error({ statusCode: 404, message: 'Plan existiert nicht' });
       return;
     }
 
-    if (process.client || !store.state.lazyLoad) {
+    if (!store.state.lazyLoad) {
       await store.dispatch('splus/load');
-    } else {
-      console.log('lazy loading is enabled: not fetching any lectures');
     }
   },
   middleware: 'cached',

--- a/store/index.js
+++ b/store/index.js
@@ -9,7 +9,7 @@ export const state = () => ({
    * Set to true by vuex-persist during restoration.
    */
   browserStateReady: false,
-    /**
+  /**
    * If true, do not load lectures on the server.
    * true if frontend is a static build.
    */
@@ -27,5 +27,20 @@ export const mutations = {
   },
   dequeueError(state){
     state.errorQueue.shift();
-  }
+  },
+};
+
+export const actions = {
+  async nuxtServerInit({ commit, dispatch }) {
+    if (process.static) {
+      commit('enableLazyLoad');
+      return;
+    }
+
+    await Promise.all([
+      dispatch('mensa/load'),
+      dispatch('news/loadCampusNews'),
+      dispatch('news/loadFacultyNews'),
+    ]);
+  },
 }


### PR DESCRIPTION
nuxtServerInit ist eine action in `store/index`, die (nur) serverseitig einmalig ausgeführt wird. Weil die action vor den middlewares ausgeführt wird, werden auftretende Fehlermeldungen erkannt und im Fehlerfall keine Cache-Header gesetzt.

Probleme / Nachteile: In der Implementierung dieses PRs werden die Mensa- und Newsdaten immer und die Plandaten nie in server init geladen. Heißt:
* bei einem direkten Seitenaufruf eines Plans werden unnötig Daten geladen
* tritt ein Fehler nur bei der splus-API auf und nicht bei den anderen, wird trotzdem der cache header für diese Planseite gesetzt

Weil die meisten Nutzer aber über das Dashboard kommen und die API nur Totalausfall hat, halte ich das erst einmal für annehmbar.

Dokumentation: https://nuxtjs.org/guide/vuex-store#the-nuxtserverinit-action
Follow-up auf #244 

