### PR TITLE
Remove lecture caching from splus store

### DIFF
--- a/components/spluseins-calendar.vue
+++ b/components/spluseins-calendar.vue
@@ -77,7 +77,7 @@ export default {
     }),
   },
   watch: {
-    'events': function(events) {
+    events(events) {
       this.calendar.setEvents(events);
     },
     'currentWeek': 'loadLectures',
@@ -96,7 +96,7 @@ export default {
       setWeek: 'splus/setWeek',
     }),
     ...mapActions({
-      loadLectures: 'splus/loadPrefetching',
+      loadLectures: 'splus/load',
     }),
   },
 };


### PR DESCRIPTION
Vereinfache den splus-Store durch das Entfernen des lecture-Cachings und durch Extrahieren von timetable und upcoming timetable gemeinsamer Logik.