### PR TITLE
Calendar: Block week change until lectures are loaded

### DIFF
--- a/components/dayspan-custom-calendar.vue
+++ b/components/dayspan-custom-calendar.vue
@@ -237,8 +237,6 @@ export default {
         : Sorts.Start;
 
       this.calendar.set( state );
-
-      this.triggerChange();
     },
 
     isType(type, aroundDay)
@@ -277,42 +275,23 @@ export default {
 
     next()
     {
-      this.calendar.unselect().next();
-
-      this.triggerChange();
+      this.$emit('next');
     },
 
     prev()
     {
-      this.calendar.unselect().prev();
-
-      this.triggerChange();
+      this.$emit('prev');
     },
 
     setToday()
     {
-      const around = Day.fromMoment(moment().startOf('isoWeek'));
-      this.rebuild(around);
+      this.$emit('today');
     },
 
     viewDay(day)
     {
       this.rebuild( day, false, this.types[ 0 ] );
     },
-
-    eventsRefresh()
-    {
-      this.calendar.refreshEvents();
-
-      this.triggerChange();
-    },
-
-    triggerChange()
-    {
-      this.$emit('change', {
-        calendar: this.calendar
-      });
-    }
   }
 }
 </script>


### PR DESCRIPTION
Vorher:
* dayspan-custom-calendar ändert die Woche
* spluseins-calendar watcht die Woche, lädt und aktualisiert die Events
* dayspan-custom-calendar aktualisiert die Events

Das Problem ist, dass der Kalender für kurze Zeit leer ist. So flackert er.

Mit diesen Änderungen:
* dayspan-custom-calendar feuert die Events today/next/prev
* spluseins-calendar hört auf das Event, lädt die Daten, aktualisiert die Events und wechselt dann die Kalender-Ansicht