### PR TITLE
Refactor and relayout upcoming lectures card

### DIFF
--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -30,8 +30,10 @@
     />
 
     <v-card-actions>
+      <v-spacer />
       <v-btn
         v-show="hasManySubscribableTimetables"
+        color="primary"
         flat
         @click="dialogOpen = true; $track('Calendar', 'openSelectTimetable')"
       >

--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -2,7 +2,7 @@
   <v-card>
     <v-card-title>
       <h3 class="headline">
-        Nächste Vorlesung für {{ selectedItem.longDescription || selectedItem.label }}
+        Nächste Vorlesung
       </h3>
     </v-card-title>
 

--- a/components/upcoming-lectures-card.vue
+++ b/components/upcoming-lectures-card.vue
@@ -1,40 +1,43 @@
 <template>
   <v-card>
     <v-card-title>
-      <span class="headline">Nächste Vorlesung</span>
-      <v-btn
-        v-show="hasSubscribableTimetables"
-        icon
-        @click="dialogOpen = true; $track('Calendar', 'openSelectTimetable')"
-      >
-        <v-icon>mdi-bookmark-outline</v-icon>
-      </v-btn>
+      <h3 class="headline">
+        Nächste Vorlesung für {{ selectedItem.longDescription || selectedItem.label }}
+      </h3>
     </v-card-title>
 
-    <v-card-text v-if="nextEvent != undefined">
-      <b>{{ nextEvent.title }} {{ nextEvent.lecturer }}</b>
-      <br>
-      Datum: {{ nextEvent.start.format('dddd, DD.MM.YYYY') }}
-      <br>
-      Uhrzeit: {{ nextEvent.start.hour() }}:{{ nextEvent.start.minute() == 0? "00" : nextEvent.start.minute() }} Uhr
-      <br>
-      <span v-if="!!nextEvent.room">
-        Raum: {{ nextEvent.room }}
-      </span>
-    </v-card-text>
-    <v-card-text v-else-if="hasSubscribableTimetables && nextEvent == undefined">
-      <i>Keine weiteren Vorlesungen in dieser Woche!</i>
-    </v-card-text>
-    <v-card-text v-else>
-      <i>Markiere bitte Favoriten oder erstelle personalisierte Pläne, um diese Option nutzen zu können!</i>
+    <v-card-text>
+      <ul
+        v-if="nextEvent != undefined"
+        class="event-description"
+      >
+        <li>{{ nextEvent.title }} {{ nextEvent.meta.organiserName }}</li>
+        <li>Datum: {{ nextEvent.start.format('dddd, DD.MM.YYYY') }}</li>
+        <li>Uhrzeit: {{ nextEvent.start.format('HH:mm') }} Uhr</li>
+        <li v-if="!!nextEvent.location">
+          Raum: {{ nextEvent.location }}
+        </li>
+      </ul>
+      <span v-else-if="hasSubscribableTimetables">Keine weiteren Vorlesungen in dieser Woche.</span>
+      <span v-else>Markiere Favoriten oder erstelle personalisierte Pläne, um diese Option nutzen zu können.</span>
     </v-card-text>
 
     <select-dialog
       :open.sync="dialogOpen"
       :items="subscribableTimetables"
       :selected.sync="selectedItem"
-      title="Plan abonnieren"
+      title="Plan wählen"
     />
+
+    <v-card-actions>
+      <v-btn
+        v-show="hasManySubscribableTimetables"
+        flat
+        @click="dialogOpen = true; $track('Calendar', 'openSelectTimetable')"
+      >
+        Plan wählen
+      </v-btn>
+    </v-card-actions>
   </v-card>
 </template>
 
@@ -50,72 +53,61 @@ export default {
   },
   data() {
     return {
-      nextEvent: undefined,
       dialogOpen: false,
     }
   },
   computed: {
     selectedItem: {
-      get(){ return this.subscribedTimetable;},
-      set(value){ this.setSubscribedTimetable(value);}
+      get(){ return this.subscribedTimetable; },
+      set(value){ this.selectSubscribedTimetable(value); }
+    },
+    nextEvent() {
+      const now = moment();
+      const isInFuture = (event) => event.start.valueOf() - now.valueOf() > 0;
+
+      const futureEvents = this.upcomingEvents
+        .map((event) => ({
+          ...event,
+          start: moment(event.start),
+        }))
+        .filter(isInFuture)
+        .sort((a, b) => a.start.valueOf() - b.start.valueOf());
+
+      return futureEvents.length > 0 ? futureEvents[0] : undefined;
+    },
+    hasManySubscribableTimetables() {
+      return this.subscribableTimetables.length > 1;
     },
     ...mapState({
-      upcomingLectures: (state) => state.splus.upcomingLectures,
-      upcomingLecturesTimetable: (state) => state.splus.upcomingLecturesTimetable,
+      upcomingEvents: (state) => state.splus.upcomingEvents,
       subscribedTimetable: (state) => state.splus.subscribedTimetable,
-      browserStateReady: (state) => state.browserStateReady,
     }),
     ...mapGetters({
       subscribableTimetables: 'splus/subscribableTimetables',
       hasSubscribableTimetables: 'splus/hasSubscribableTimetables',
     }),
   },
-  watch: {
-    subscribedTimetable() {
-      if(this.browserStateReady && !!this.subscribedTimetable.id){
-        this.load();
-      }
-    },
-    upcomingLectures() {
-      this.nextEvent = this.findNextEvent();
-    },
-  },
-  mounted() {
-    if(!!this.subscribedTimetable.id) {
-       this.load();
-    }
-  },
   methods: {
+    selectSubscribedTimetable(timetable) {
+      this.setSubscribedTimetable(timetable);
+      this.loadFutureEvents();
+    },
     ...mapMutations({
       setSubscribedTimetable: 'splus/setSubscribedTimetable',
-      setUpcomingLecturesTimetable: 'splus/setUpcomingLecturesTimetable',
     }),
     ...mapActions({
-      loadLectures: 'splus/loadUpcomingLectures',
+      loadFutureEvents: 'splus/loadUpcomingLectures',
     }),
-    findNextEvent() {
-      const possibleEvents = this.upcomingLectures
-                             .map(event => {return {title: event.title,
-                                                    room: event.room,
-                                                    lecturer: event.lecturer,
-                                                    start: moment(event.start).hour(parseInt(event.begin / 1)).minute(event.begin % 1 * 60)}})
-                             .filter(event => event.start.valueOf() - moment().valueOf() > 0)
-                             .sort((a,b) => a.start.valueOf() - b.start.valueOf());
-      return possibleEvents[0] != undefined? possibleEvents[0] : undefined;
-    },
-    load(){
-      this.setUpcomingLecturesTimetable(this.subscribedTimetable);
-      this.loadLectures();
-    }
-  }
+  },
 };
 </script>
 
 <style lang="scss">
-
-.v-card__text{
-  padding-top: 0px;
+.event-description {
+  padding-left: 0;
+  & > li {
+    list-style: none;
+  }
 }
-
 </style>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -161,12 +161,18 @@ export default {
   },
   watch: {
     browserStateReady() {
+      this.load();
+    },
+  },
+  mounted() {
+    this.load();
+  },
+  methods: {
+    load() {
       if (Object.keys(this.subscribedTimetable).length > 0) {
         this.loadFutureEvents();
       }
     },
-  },
-  methods: {
     ...mapMutations({
       setSidenav: 'ui/setSidenav',
     }),

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapMutations } from 'vuex';
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
 import * as moment from 'moment';
 import UpcomingLecturesCard from '../components/upcoming-lectures-card.vue';
 import LastChangesCard from '../components/last-changes-card.vue';
@@ -142,6 +142,8 @@ export default {
       campusNews: (state) => state.news.campusNews,
       facultyNews: (state) => state.news.facultyNews,
       upcomingLectures: (state) => state.splus.upcomingLectures,
+      browserStateReady: (state) => state.browserStateReady,
+      subscribedTimetable: (state) => state.splus.subscribedTimetable,
     }),
     ...mapGetters({
       customSchedulesAsRoutes: 'splus/customSchedulesAsRoutes',
@@ -157,9 +159,19 @@ export default {
       ],
     };
   },
+  watch: {
+    browserStateReady() {
+      if (Object.keys(this.subscribedTimetable).length > 0) {
+        this.loadFutureEvents();
+      }
+    },
+  },
   methods: {
     ...mapMutations({
       setSidenav: 'ui/setSidenav',
+    }),
+    ...mapActions({
+      loadFutureEvents: 'splus/loadUpcomingLectures',
     }),
   },
   middleware: 'cached',

--- a/store/splus.js
+++ b/store/splus.js
@@ -101,7 +101,6 @@ export const state = () => ({
   /**
    * state for upcoming-lectures-card
    */
-  upcomingLecturesTimetable: undefined,
   upcomingEvents: [],
   upcomingLectures: [], // TODO deprecated in favor of events
 });
@@ -233,9 +232,6 @@ export const mutations = {
   setSchedule(state, timetable) {
     state.schedule = timetable;
   },
-  setUpcomingLecturesTimetable(state, timetable) {
-    state.upcomingLecturesTimetable = timetable;
-  },
   addCustomSchedule(state, customTimetable) {
     const label = customTimetable.label;
     const customTimetableStored = state.customSchedules[label];
@@ -303,11 +299,11 @@ export const actions = {
     }
   },
   /**
-   * Request lectures of upcomingLecturesTimetable for defaultWeek
+   * Request lectures of subscribedTimetable for defaultWeek
    */
   async loadUpcomingLectures({ state, commit }) {
     try {
-      const events = await loadEvents(state.upcomingLecturesTimetable, defaultWeek(), this.$axios.$get);
+      const events = await loadEvents(state.subscribedTimetable, defaultWeek(), this.$axios.$get);
       const lectures = eventsAsLectures(events);
       commit('setUpcomingLectures', lectures);
       commit('setUpcomingEvents', events);


### PR DESCRIPTION
* ersetze upcomingLecturesTimetable durch subscribedTimetable, das war redundant
* lade die upcoming events im Dashboard, da die stats card die Daten auch braucht
* bewege den Abonnement-Button in die card-actions-Zeile und gib ihm einen aussagekräftigen Namen
* nutze computed properties statt watcher->method->data für den Datenfluss für bessere Performance und simpleren Code
* nutze eine Liste für die Beschreibung für semantischeres HTML
* schreibe den abonnierten Plan in den Kartentitel

`now = moment().startOf('week')` ist gut zum testen