### PR TITLE
Custom event popover: Enable hydration, fixes inactive close button

### DIFF
--- a/components/dayspan-custom-event-popover.vue
+++ b/components/dayspan-custom-event-popover.vue
@@ -1,5 +1,5 @@
 <template>
-  <lazy-hydrate ssr-only>
+  <lazy-hydrate when-visible>
     <v-card class="ds-calendar-event-popover-card">
       <v-toolbar
         :style="styleHeader"


### PR DESCRIPTION
Was bisher passiert (happy path):
  * Der Nutzer lädt die Startseite, diese wird auf dem Server gerendert
  * Der Nutzer lädt einen Plan, dieser wird auf dem Client gerendert, der @close-Handler wird deswegen attached

Was bisher passiert (Fehlerfall):
  * Der Nutzer lädt einen Plan direkt, dieser wird auf dem Server gerendert
  * Der Client lädt Vue für diese Komponente nicht (`ssr-only`, das verbessert die Performanz). Kein @close-Handler wird attached! Die Karte lässt sich nicht schließen.