### PR TITLE
Bus API: Hotfix missing reference to fetch in production build

### DIFF
--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -39,6 +39,7 @@ const serverlessConfig = {
   },
   resolve: {
     extensions: [ '.ts', '.js' ],
+    mainFields: [ 'main' ],
   },
 };
 
@@ -63,6 +64,7 @@ const serverConfig = {
   },
   resolve: {
     extensions: [ '.ts', '.js' ],
+    mainFields: [ 'main' ],
   },
 };
 


### PR DESCRIPTION
`fetch` wird nicht korrekt gepolyifillt, siehe https://github.com/bitinn/node-fetch/issues/450#issuecomment-494475397