### PR TITLE
Update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-vue": "^5.2.3",
     "jest": "^24.9.0",
     "jest-serializer-vue": "^2.0.2",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.13.0",
     "nodemon": "^1.19.3",
     "sass-loader": "^7.3.1",
     "stylus": "^0.54.7",


### PR DESCRIPTION
Es gibt nun node-sass 4.13. Die Version 4.12 kann nicht mehr als Release von GitHub gedownloaded werden und deshalb schlägt der Netlify Build immer fehl. Man muss immer einen Cache Wipe machen.