### PR TITLE
Use default description for index page

### DIFF
--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -154,10 +154,6 @@ export default {
   head() {
     return {
       title: 'Startseite',
-      meta: [
-        { hid: 'description', name: 'description', content: 'Startseite' },
-        { hid: 'og:description', property: 'og:description', content: 'Startseite' },
-      ],
     };
   },
   methods: {


### PR DESCRIPTION
Die Beschreibung für Suchmaschinen für die Homepage war bisher "Startseite", mit dieser Änderung wird es die in nuxt.config.js geschriebene