### PR TITLE
Fix TypeError when matomo is blocked

### DIFF
--- a/web/components/spluseins-cookie-snackbar.vue
+++ b/web/components/spluseins-cookie-snackbar.vue
@@ -53,7 +53,7 @@ export default {
   },
   watch: {
     allowAllCookies() {
-      if (this.browserStateReady) {
+      if (this.browserStateReady && '$matomo' in this) {
         if (this.allowAllCookies == false) {
           this.$matomo.disableCookies();
           this.$matomo.deleteCookies();

--- a/web/plugins/vue-matomo.js
+++ b/web/plugins/vue-matomo.js
@@ -12,6 +12,8 @@ export default ({ app }, inject) =>{
     trackerFileName: 'piwik',
   });
   inject('track', function (category, action, name, value) {
-    this.$matomo.trackEvent(category, action, name, value);
+    if ('$matomo' in this) {
+      this.$matomo.trackEvent(category, action, name, value);
+    }
   });
 };


### PR DESCRIPTION
Wenn ich AdBlock an habe, lädt das Matomo-Skript nicht und beim Interagieren mit dem Cookie-Popup bekomme ich Serverfehler :(
Gefixt mit zwei ifs