### PR TITLE
Allow injection of team members via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Environment variables:
   * `SPLUS_CACHE_SECONDS` (backend): timetable memory and header cache duration
   * `NEWS_CACHE_SECONDS` (backend): news memory and header cache duration
   * `MENSA_CACHE_SECONDS` (backend): mensa memory and header cache duration
+  * `PROTECTED_INFORMATION` (frontend): team members for Impressum/Datenschutz

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -1,5 +1,6 @@
 import VuetifyLoaderPlugin from 'vuetify-loader/lib/plugin';
 import webpack from 'webpack';
+import PROTECTED_INFORMATION from './assets/protected-information.json';
 
 export default {
   mode: 'universal',
@@ -85,6 +86,10 @@ export default {
   ** Axios module configuration
   */
   axios: {
+  },
+
+  env: {
+    team: ('PROTECTED_INFORMATION' in process.env ? JSON.parse(process.env.PROTECTED_INFORMATION) : PROTECTED_INFORMATION).team,
   },
 
   /*

--- a/web/pages/datenschutz.vue
+++ b/web/pages/datenschutz.vue
@@ -110,7 +110,6 @@
 
 <script>
 import { mapMutations } from 'vuex';
-import PROTECTED_INFORMATION from '~/assets/protected-information.json';
 
 export default {
   name: 'SpluseinsDataPrivacy',
@@ -125,7 +124,7 @@ export default {
   },
   data() {
     return {
-      team: PROTECTED_INFORMATION.team
+      team: process.env.team,
     }
   },
   methods: {

--- a/web/pages/impressum.vue
+++ b/web/pages/impressum.vue
@@ -53,7 +53,6 @@
 
 <script>
 import { mapMutations } from 'vuex';
-import PROTECTED_INFORMATION from '~/assets/protected-information.json';
 
 export default {
   name: 'SpluseinsImpressum',
@@ -68,7 +67,7 @@ export default {
   },
   data() {
     return {
-      team: PROTECTED_INFORMATION.team
+      team: process.env.team,
     }
   },
   methods: {


### PR DESCRIPTION
In der nuxt config wird beim build `PROTECTED_INFORMATION` aus den Umgebungsvariablen geladen und daraus das Team als `process.env.team` in die Komponenten geschrieben.

https://nuxtjs.org/api/configuration-env/

…das macht das Deployment einfacher

