### PR TITLE
Add faculty E timetables

### DIFF
--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -269,5 +269,293 @@
     "semester": "Alle",
     "graphical": false,
     "skedPath": "/i/Semester/Semester-Liste/M.Sc. Informatik (Alle Sem.+Schwerpunkte).html"
+  },
+  {
+    "id": "elektro-eit-1",
+    "label": "EIT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT-GS-Sem1.html"
+  },
+  {
+    "id": "elektro-eitip-1",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-EITiP-GS-Sem1.html"
+  },
+  {
+    "id": "elektro-eitweit-1",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT-Sem1.html"
+  },
+  {
+    "id": "elektro-weitip-1",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEITiP-Sem1.html"
+  },
+  {
+    "id": "elektro-eitip-2",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "2",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-GS-Sem2.html"
+  },
+  {
+    "id": "elektro-weitip-2",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "2",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem2.html"
+  },
+  {
+    "id": "elektro-eitip-3",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "3",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html"
+  },
+  {
+    "id": "elektro-weitip-3",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "3",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html"
+  },
+  {
+    "id": "elektro-eitipat-4",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipat-5",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipat-6",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html"
+  },
+  {
+    "id": "elektro-eitipee-4",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipee-5",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipee-6",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html"
+  },
+  {
+    "id": "elektro-eitipit-4",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipit-5",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipit-6",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html"
+  },
+  {
+    "id": "elektro-weitip-4",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem4.html"
+  },
+  {
+    "id": "elektro-weitip-5",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html"
+  },
+  {
+    "id": "elektro-weitip-6",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipat-4",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipat-5",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipat-6",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipee-4",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipee-5",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipee-6",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipit-4",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipit-5",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipit-6",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem6.html"
+  },
+  {
+    "id": "elektro-block-weitip-4",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem4.html"
+  },
+  {
+    "id": "elektro-block-weitip-5",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem5.html"
+  },
+  {
+    "id": "elektro-block-weitip-6",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem6.html"
   }
 ]

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -281,7 +281,7 @@
   },
   {
     "id": "elektro-eitip-1",
-    "label": "EIT-iP",
+    "label": "EITiP",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "1",
@@ -299,7 +299,7 @@
   },
   {
     "id": "elektro-weitip-1",
-    "label": "WEIT-iP",
+    "label": "WEITiP",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "1",
@@ -308,7 +308,7 @@
   },
   {
     "id": "elektro-eitip-2",
-    "label": "EIT-iP",
+    "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "2",
@@ -317,7 +317,7 @@
   },
   {
     "id": "elektro-weitip-2",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "2",
@@ -326,7 +326,7 @@
   },
   {
     "id": "elektro-eitip-3",
-    "label": "EIT-iP",
+    "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "3",
@@ -335,7 +335,7 @@
   },
   {
     "id": "elektro-weitip-3",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "3",
@@ -344,7 +344,7 @@
   },
   {
     "id": "elektro-eitipat-4",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -353,7 +353,7 @@
   },
   {
     "id": "elektro-eitipat-5",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -362,7 +362,7 @@
   },
   {
     "id": "elektro-eitipat-6",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -371,7 +371,7 @@
   },
   {
     "id": "elektro-eitipee-4",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -380,7 +380,7 @@
   },
   {
     "id": "elektro-eitipee-5",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -389,7 +389,7 @@
   },
   {
     "id": "elektro-eitipee-6",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -398,7 +398,7 @@
   },
   {
     "id": "elektro-eitipit-4",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -407,7 +407,7 @@
   },
   {
     "id": "elektro-eitipit-5",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -416,7 +416,7 @@
   },
   {
     "id": "elektro-eitipit-6",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -425,7 +425,7 @@
   },
   {
     "id": "elektro-weitip-4",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -434,7 +434,7 @@
   },
   {
     "id": "elektro-weitip-5",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -443,7 +443,7 @@
   },
   {
     "id": "elektro-weitip-6",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -452,7 +452,7 @@
   },
   {
     "id": "elektro-block-eitipat-4",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -461,7 +461,7 @@
   },
   {
     "id": "elektro-block-eitipat-5",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -470,7 +470,7 @@
   },
   {
     "id": "elektro-block-eitipat-6",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -479,7 +479,7 @@
   },
   {
     "id": "elektro-block-eitipee-4",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -488,7 +488,7 @@
   },
   {
     "id": "elektro-block-eitipee-5",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -497,7 +497,7 @@
   },
   {
     "id": "elektro-block-eitipee-6",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -506,7 +506,7 @@
   },
   {
     "id": "elektro-block-eitipit-4",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -515,7 +515,7 @@
   },
   {
     "id": "elektro-block-eitipit-5",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -524,7 +524,7 @@
   },
   {
     "id": "elektro-block-eitipit-6",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -533,7 +533,7 @@
   },
   {
     "id": "elektro-block-weitip-4",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -542,7 +542,7 @@
   },
   {
     "id": "elektro-block-weitip-5",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -551,7 +551,7 @@
   },
   {
     "id": "elektro-block-weitip-6",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -277,7 +277,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT-GS-Sem1.html"
+    "skedPath": "/e/semester/E-EIT-GS-Sem1.html"
   },
   {
     "id": "elektro-eitip-1",
@@ -286,7 +286,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-EITiP-GS-Sem1.html"
+    "skedPath": "/e/semester/E-EITiP-GS-Sem1.html"
   },
   {
     "id": "elektro-eitweit-1",
@@ -295,7 +295,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT-Sem1.html"
+    "skedPath": "/e/semester/E-WEIT-Sem1.html"
   },
   {
     "id": "elektro-weitip-1",
@@ -304,7 +304,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-WEITiP-Sem1.html"
+    "skedPath": "/e/semester/E-WEITiP-Sem1.html"
   },
   {
     "id": "elektro-eitip-2",
@@ -313,7 +313,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "2",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-GS-Sem2.html"
+    "skedPath": "/e/semester/E-EIT(iP)-GS-Sem2.html"
   },
   {
     "id": "elektro-weitip-2",
@@ -322,7 +322,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "2",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem2.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem2.html"
   },
   {
     "id": "elektro-eitip-3",
@@ -331,7 +331,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "3",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html"
+    "skedPath": "/e/semester/E-EIT(iP)-GS-Sem3.html"
   },
   {
     "id": "elektro-weitip-3",
@@ -340,7 +340,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "3",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem3.html"
   },
   {
     "id": "elektro-eitipat-4",
@@ -349,7 +349,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem4.html"
   },
   {
     "id": "elektro-eitipat-5",
@@ -358,7 +358,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem5.html"
   },
   {
     "id": "elektro-eitipat-6",
@@ -367,7 +367,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem6.html"
   },
   {
     "id": "elektro-eitipee-4",
@@ -376,7 +376,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem4.html"
   },
   {
     "id": "elektro-eitipee-5",
@@ -385,7 +385,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem5.html"
   },
   {
     "id": "elektro-eitipee-6",
@@ -394,7 +394,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem6.html"
   },
   {
     "id": "elektro-eitipit-4",
@@ -403,7 +403,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem4.html"
   },
   {
     "id": "elektro-eitipit-5",
@@ -412,7 +412,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem5.html"
   },
   {
     "id": "elektro-eitipit-6",
@@ -421,7 +421,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem6.html"
   },
   {
     "id": "elektro-weitip-4",
@@ -430,7 +430,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem4.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem4.html"
   },
   {
     "id": "elektro-weitip-5",
@@ -439,7 +439,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem5.html"
   },
   {
     "id": "elektro-weitip-6",
@@ -448,7 +448,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem6.html"
   },
   {
     "id": "elektro-block-eitipat-4",
@@ -457,7 +457,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem4.html"
   },
   {
     "id": "elektro-block-eitipat-5",
@@ -466,7 +466,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem5.html"
   },
   {
     "id": "elektro-block-eitipat-6",
@@ -475,7 +475,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem6.html"
   },
   {
     "id": "elektro-block-eitipee-4",
@@ -484,7 +484,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem4.html"
   },
   {
     "id": "elektro-block-eitipee-5",
@@ -493,7 +493,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem5.html"
   },
   {
     "id": "elektro-block-eitipee-6",
@@ -502,7 +502,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem6.html"
   },
   {
     "id": "elektro-block-eitipit-4",
@@ -511,7 +511,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem4.html"
   },
   {
     "id": "elektro-block-eitipit-5",
@@ -520,7 +520,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem5.html"
   },
   {
     "id": "elektro-block-eitipit-6",
@@ -529,7 +529,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem6.html"
   },
   {
     "id": "elektro-block-weitip-4",
@@ -538,7 +538,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem4.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem4.html"
   },
   {
     "id": "elektro-block-weitip-5",
@@ -547,7 +547,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem5.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem5.html"
   },
   {
     "id": "elektro-block-weitip-6",
@@ -556,6 +556,6 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem6.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem6.html"
   }
 ]

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -269,5 +269,293 @@
     "semester": "Alle",
     "graphical": false,
     "skedPath": "/i/Semester/Semester-Liste/M.Sc. Informatik (Alle Sem.+Schwerpunkte).html"
+  },
+  {
+    "id": "elektro-eit-1",
+    "label": "EIT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT-GS-Sem1.html"
+  },
+  {
+    "id": "elektro-eitip-1",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-EITiP-GS-Sem1.html"
+  },
+  {
+    "id": "elektro-eitweit-1",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT-Sem1.html"
+  },
+  {
+    "id": "elektro-weitip-1",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "1",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEITiP-Sem1.html"
+  },
+  {
+    "id": "elektro-eitip-2",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "2",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-GS-Sem2.html"
+  },
+  {
+    "id": "elektro-weitip-2",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "2",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem2.html"
+  },
+  {
+    "id": "elektro-eitip-3",
+    "label": "EIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "3",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html"
+  },
+  {
+    "id": "elektro-weitip-3",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "3",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html"
+  },
+  {
+    "id": "elektro-eitipat-4",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipat-5",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipat-6",
+    "label": "EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html"
+  },
+  {
+    "id": "elektro-eitipee-4",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipee-5",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipee-6",
+    "label": "EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html"
+  },
+  {
+    "id": "elektro-eitipit-4",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html"
+  },
+  {
+    "id": "elektro-eitipit-5",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html"
+  },
+  {
+    "id": "elektro-eitipit-6",
+    "label": "EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html"
+  },
+  {
+    "id": "elektro-weitip-4",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem4.html"
+  },
+  {
+    "id": "elektro-weitip-5",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html"
+  },
+  {
+    "id": "elektro-weitip-6",
+    "label": "WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": true,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipat-4",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipat-5",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipat-6",
+    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-AT-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipee-4",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipee-5",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipee-6",
+    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-EE-Sem6.html"
+  },
+  {
+    "id": "elektro-block-eitipit-4",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem4.html"
+  },
+  {
+    "id": "elektro-block-eitipit-5",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem5.html"
+  },
+  {
+    "id": "elektro-block-eitipit-6",
+    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-EIT(iP)-IT-Sem6.html"
+  },
+  {
+    "id": "elektro-block-weitip-4",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "4",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem4.html"
+  },
+  {
+    "id": "elektro-block-weitip-5",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "5",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem5.html"
+  },
+  {
+    "id": "elektro-block-weitip-6",
+    "label": "Blockveranstaltungen-WEIT-iP",
+    "faculty": "Elektrotechnik",
+    "degree": "Bachelor of Engineering",
+    "semester": "6",
+    "graphical": false,
+    "skedPath": "e/block/E-WEIT(iP)-Sem6.html"
   }
 ]

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -281,7 +281,7 @@
   },
   {
     "id": "elektro-eitip-1",
-    "label": "EIT-iP",
+    "label": "EITiP",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "1",
@@ -299,7 +299,7 @@
   },
   {
     "id": "elektro-weitip-1",
-    "label": "WEIT-iP",
+    "label": "WEITiP",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "1",
@@ -308,7 +308,7 @@
   },
   {
     "id": "elektro-eitip-2",
-    "label": "EIT-iP",
+    "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "2",
@@ -317,7 +317,7 @@
   },
   {
     "id": "elektro-weitip-2",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "2",
@@ -326,7 +326,7 @@
   },
   {
     "id": "elektro-eitip-3",
-    "label": "EIT-iP",
+    "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "3",
@@ -335,7 +335,7 @@
   },
   {
     "id": "elektro-weitip-3",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "3",
@@ -344,7 +344,7 @@
   },
   {
     "id": "elektro-eitipat-4",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -353,7 +353,7 @@
   },
   {
     "id": "elektro-eitipat-5",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -362,7 +362,7 @@
   },
   {
     "id": "elektro-eitipat-6",
-    "label": "EIT-iP-AT",
+    "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -371,7 +371,7 @@
   },
   {
     "id": "elektro-eitipee-4",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -380,7 +380,7 @@
   },
   {
     "id": "elektro-eitipee-5",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -389,7 +389,7 @@
   },
   {
     "id": "elektro-eitipee-6",
-    "label": "EIT-iP-EE",
+    "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -398,7 +398,7 @@
   },
   {
     "id": "elektro-eitipit-4",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -407,7 +407,7 @@
   },
   {
     "id": "elektro-eitipit-5",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -416,7 +416,7 @@
   },
   {
     "id": "elektro-eitipit-6",
-    "label": "EIT-iP-IT",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -425,7 +425,7 @@
   },
   {
     "id": "elektro-weitip-4",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -434,7 +434,7 @@
   },
   {
     "id": "elektro-weitip-5",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -443,7 +443,7 @@
   },
   {
     "id": "elektro-weitip-6",
-    "label": "WEIT-iP",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -452,7 +452,7 @@
   },
   {
     "id": "elektro-block-eitipat-4",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -461,7 +461,7 @@
   },
   {
     "id": "elektro-block-eitipat-5",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -470,7 +470,7 @@
   },
   {
     "id": "elektro-block-eitipat-6",
-    "label": "Blockveranstaltungen-EIT-iP-AT",
+    "label": "Blockveranstaltungen-EIT(iP)-AT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -479,7 +479,7 @@
   },
   {
     "id": "elektro-block-eitipee-4",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -488,7 +488,7 @@
   },
   {
     "id": "elektro-block-eitipee-5",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -497,7 +497,7 @@
   },
   {
     "id": "elektro-block-eitipee-6",
-    "label": "Blockveranstaltungen-EIT-iP-EE",
+    "label": "Blockveranstaltungen-EIT(iP)-EE",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -506,7 +506,7 @@
   },
   {
     "id": "elektro-block-eitipit-4",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -515,7 +515,7 @@
   },
   {
     "id": "elektro-block-eitipit-5",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -524,7 +524,7 @@
   },
   {
     "id": "elektro-block-eitipit-6",
-    "label": "Blockveranstaltungen-EIT-iP-IT",
+    "label": "Blockveranstaltungen-EIT(iP)-IT",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",
@@ -533,7 +533,7 @@
   },
   {
     "id": "elektro-block-weitip-4",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "4",
@@ -542,7 +542,7 @@
   },
   {
     "id": "elektro-block-weitip-5",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "5",
@@ -551,7 +551,7 @@
   },
   {
     "id": "elektro-block-weitip-6",
-    "label": "Blockveranstaltungen-WEIT-iP",
+    "label": "Blockveranstaltungen-WEIT(iP)",
     "faculty": "Elektrotechnik",
     "degree": "Bachelor of Engineering",
     "semester": "6",

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -277,7 +277,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT-GS-Sem1.html"
+    "skedPath": "/e/semester/E-EIT-GS-Sem1.html"
   },
   {
     "id": "elektro-eitip-1",
@@ -286,7 +286,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-EITiP-GS-Sem1.html"
+    "skedPath": "/e/semester/E-EITiP-GS-Sem1.html"
   },
   {
     "id": "elektro-eitweit-1",
@@ -295,7 +295,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT-Sem1.html"
+    "skedPath": "/e/semester/E-WEIT-Sem1.html"
   },
   {
     "id": "elektro-weitip-1",
@@ -304,7 +304,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "1",
     "graphical": true,
-    "skedPath": "e/semester/E-WEITiP-Sem1.html"
+    "skedPath": "/e/semester/E-WEITiP-Sem1.html"
   },
   {
     "id": "elektro-eitip-2",
@@ -313,7 +313,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "2",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-GS-Sem2.html"
+    "skedPath": "/e/semester/E-EIT(iP)-GS-Sem2.html"
   },
   {
     "id": "elektro-weitip-2",
@@ -322,7 +322,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "2",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem2.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem2.html"
   },
   {
     "id": "elektro-eitip-3",
@@ -331,7 +331,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "3",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html"
+    "skedPath": "/e/semester/E-EIT(iP)-GS-Sem3.html"
   },
   {
     "id": "elektro-weitip-3",
@@ -340,7 +340,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "3",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem3.html"
   },
   {
     "id": "elektro-eitipat-4",
@@ -349,7 +349,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem4.html"
   },
   {
     "id": "elektro-eitipat-5",
@@ -358,7 +358,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem5.html"
   },
   {
     "id": "elektro-eitipat-6",
@@ -367,7 +367,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-AT-Sem6.html"
   },
   {
     "id": "elektro-eitipee-4",
@@ -376,7 +376,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem4.html"
   },
   {
     "id": "elektro-eitipee-5",
@@ -385,7 +385,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem5.html"
   },
   {
     "id": "elektro-eitipee-6",
@@ -394,7 +394,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-EE-Sem6.html"
   },
   {
     "id": "elektro-eitipit-4",
@@ -403,7 +403,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem4.html"
   },
   {
     "id": "elektro-eitipit-5",
@@ -412,7 +412,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem5.html"
   },
   {
     "id": "elektro-eitipit-6",
@@ -421,7 +421,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html"
+    "skedPath": "/e/semester/E-EIT(iP)-IT-Sem6.html"
   },
   {
     "id": "elektro-weitip-4",
@@ -430,7 +430,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem4.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem4.html"
   },
   {
     "id": "elektro-weitip-5",
@@ -439,7 +439,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem5.html"
   },
   {
     "id": "elektro-weitip-6",
@@ -448,7 +448,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": true,
-    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html"
+    "skedPath": "/e/semester/E-WEIT(iP)-Sem6.html"
   },
   {
     "id": "elektro-block-eitipat-4",
@@ -457,7 +457,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem4.html"
   },
   {
     "id": "elektro-block-eitipat-5",
@@ -466,7 +466,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem5.html"
   },
   {
     "id": "elektro-block-eitipat-6",
@@ -475,7 +475,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-AT-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-AT-Sem6.html"
   },
   {
     "id": "elektro-block-eitipee-4",
@@ -484,7 +484,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem4.html"
   },
   {
     "id": "elektro-block-eitipee-5",
@@ -493,7 +493,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem5.html"
   },
   {
     "id": "elektro-block-eitipee-6",
@@ -502,7 +502,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-EE-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-EE-Sem6.html"
   },
   {
     "id": "elektro-block-eitipit-4",
@@ -511,7 +511,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem4.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem4.html"
   },
   {
     "id": "elektro-block-eitipit-5",
@@ -520,7 +520,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem5.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem5.html"
   },
   {
     "id": "elektro-block-eitipit-6",
@@ -529,7 +529,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-EIT(iP)-IT-Sem6.html"
+    "skedPath": "/e/block/E-EIT(iP)-IT-Sem6.html"
   },
   {
     "id": "elektro-block-weitip-4",
@@ -538,7 +538,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "4",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem4.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem4.html"
   },
   {
     "id": "elektro-block-weitip-5",
@@ -547,7 +547,7 @@
     "degree": "Bachelor of Engineering",
     "semester": "5",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem5.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem5.html"
   },
   {
     "id": "elektro-block-weitip-6",
@@ -556,6 +556,6 @@
     "degree": "Bachelor of Engineering",
     "semester": "6",
     "graphical": false,
-    "skedPath": "e/block/E-WEIT(iP)-Sem6.html"
+    "skedPath": "/e/block/E-WEIT(iP)-Sem6.html"
   }
 ]


### PR DESCRIPTION
Hi,
wie angekündigt gibt's hier einmal die neuen URLs der Fakultät E.

Im Vergleich zum letzten Semester haben sich einmal die URLs vom Format deutlich geändert, außerdem gibt's die seperaten Matheplus-Dinger im ersten Semester nicht mehr.

Ich hab einmal alle per API only auf Availability getestet und sah gut aus. Ich hab aber die UI lokal noch nicht ans laufen bekommen, sodass vielleicht trotzdem noch obvious Fehler drin sein könnten.

URLs habe ich von https://www.ostfalia.de/cms/de/e/studium/stundenplaene/