### PR TITLE
Fix faculty news parsing

### DIFF
--- a/server/lib/NewsApi.ts
+++ b/server/lib/NewsApi.ts
@@ -112,9 +112,13 @@ async function facultyNewsRequest(faculty: String) : Promise<NewsElement[]> {
 
   return $('article.news-campus').map(function(i, article) {
     return <NewsElement> {
-      title: $('a', this).text().trim(),
-      link: 'https://www.ostfalia.de' + $('a', this).attr('href'),
-      text: $('p', this).last().text().trim(),
+      // Title is the description of the first link
+      title: $('a', this).first().text().trim(),
+      // Convert relative link into absolute
+      link: 'https://www.ostfalia.de' + $('a', this).first().attr('href'),
+      // Get last paragraph that is not empty
+      text: $('p', this).filter(function (i, el) { return $(this).text() != "" }).last().text().trim(),
+      // Convert date string (like "21.09.2020") into Date object
       date: moment($('p', this).first().text().trim(), 'DD.MM.YY').utcOffset('+0100').toDate(),
     };
   }).get();

--- a/server/lib/NewsApi.ts
+++ b/server/lib/NewsApi.ts
@@ -116,8 +116,8 @@ async function facultyNewsRequest(faculty: String) : Promise<NewsElement[]> {
       title: $('a', this).first().text().trim(),
       // Convert relative link into absolute
       link: 'https://www.ostfalia.de' + $('a', this).first().attr('href'),
-      // Get last paragraph that is not empty
-      text: $('p', this).filter(function (i, el) { return $(this).text() != "" }).last().text().trim(),
+      // Get paragraphs that are not empty but exclude the first paragraph because it contains the date
+      text: $('p', this).filter(function (i, el) { return ($(this).text().trim() != "" && i != 0) }).text().trim(),
       // Convert date string (like "21.09.2020") into Date object
       date: moment($('p', this).first().text().trim(), 'DD.MM.YY').utcOffset('+0100').toDate(),
     };


### PR DESCRIPTION
Einen hab ich noch, da die Fakultät E-News gerade etwas buggy angezeigt werden:

* When a link was in the description, its text was appended to the title. Now it's using only the first link.
* When the description contained an empty paragraph at the end it was displayed as empty. Now it selects all paragraphs but the first that are not empty