### PR TITLE
Fix ICS when no cache for that timetable is available

### DIFF
--- a/server/controllers/ics.ts
+++ b/server/controllers/ics.ts
@@ -71,7 +71,8 @@ router.get('/:version/:timetables/:lectures?', async (req, res, next) => {
       id: timetable.id,
       week: week,
       graphical: timetable.graphical,
-      faculty: timetable.faculty
+      faculty: timetable.faculty,
+      skedPath: timetable.skedPath
     })));
 
     const allEvents: Event[] = await getEvents(requests);


### PR DESCRIPTION
Previously it made requests to https://stundenplan.ostfalia.de/undefined, which ofc returns 404

Soweit ich sehe war das einfach nur ein Bug wegen fehlendem Attribut, aber evtll hab ich die Logik da auch fehl verstanden?