### PR TITLE
Fix year wraparound at end of wintersemester

### DIFF
--- a/web/components/spluseins-calendar.vue
+++ b/web/components/spluseins-calendar.vue
@@ -87,14 +87,14 @@ export default {
   },
   methods: {
     async next() {
-      this.setWeek(this.currentWeek + 1);
-      await this.refresh();
       this.calendar.next();
+      this.setWeek(this.calendar.start.date.isoWeek());
+      await this.refresh();
     },
     async prev() {
-      this.setWeek(this.currentWeek - 1);
-      await this.refresh();
       this.calendar.prev();
+      this.setWeek(this.calendar.start.date.isoWeek());
+      await this.refresh();   
     },
     async today() {
       this.resetWeek(true);

--- a/web/components/spluseins-calendar.vue
+++ b/web/components/spluseins-calendar.vue
@@ -87,28 +87,34 @@ export default {
   },
   methods: {
     async next() {
-      this.calendar.next();
-      this.setWeek(this.calendar.start.date.isoWeek());
+      // Jump forward 7 days, but do not refresh now (will be called in this.refresh())
+      this.calendar.next(7, true);
       await this.refresh();
     },
     async prev() {
-      this.calendar.prev();
-      this.setWeek(this.calendar.start.date.isoWeek());
+      // Jump back 7 days
+      this.calendar.prev(7, true);
       await this.refresh();   
     },
     async today() {
       this.resetWeek(true);
-      await this.refresh();
+      // This scrolls forward or backward until the today's week has been reached
       while (this.calendar.start.date.isoWeek() > this.currentWeek) {
-        this.calendar.prev();
+        this.calendar.prev(7, true);
       }
       while (this.calendar.start.date.isoWeek() < this.currentWeek) {
-        this.calendar.next();
+        this.calendar.next(7, true);
       }
+      await this.refresh();
     },
     async refresh() {
+      // Store the week so switching calendars keeps the same week
+      this.setWeek(this.calendar.start.date.isoWeek());
+      // Load the data and store the events in the calendar
       await this.load();
       this.calendar.setEvents(this.events);
+      // Refresh calendar AFTER the events have been loaded to avoid flickering
+      this.calendar.refresh();
     },
     ...mapMutations({
       setWeek: 'splus/setWeek',

--- a/web/store/splus.js
+++ b/web/store/splus.js
@@ -6,7 +6,9 @@ import TIMETABLES from '~/assets/timetables.json'; // TODO change this in SS21
 import { SEMESTER_WEEK_1, shortenTimetableDegree, uniq, customTimetableToRoute, scalarArraysEqual } from '~/lib/util';
 
 function defaultWeek() {
-  if (moment().isoWeek() < SEMESTER_WEEK_1) {
+  if (moment().isoWeek() < SEMESTER_WEEK_1 && (SEMESTER_WEEK_1 - moment().isoWeek) < 8) {
+    // Use semester beginning instead of today if semester hasn't started yet
+    // Do that only a few weeks before the semester so we avoid bugs with year wraparounds
     return SEMESTER_WEEK_1;
   }
 


### PR DESCRIPTION
Fixes #453. Damit kann man auch nach Ende des Jahres noch in's letzte Jahr/Wintersemester zurückgehen und vergangene Termine anschauen. Außerdem vereinheitlicht das etwas den Kalender-Code.

Im Prinzip ändert sich an der Logik nichts mit Ausnahme, dass ich `this.refresh()` und `this.calendar.next()` getauscht habe.  Damit das aber dann wegen dem Refresh nicht flickert, übergebe ich `next()` und `prev()` true als Parameter, damit er nicht automatisch refresht. 

Der Calender wird dann in der `refresh()`-Funktion manuell erneuert. 
