### PR TITLE
Implement unique lecture fetch in backend and improve backend caching

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -24,7 +24,7 @@ Die API des Servers wird grundlegend über die Controller, welche sich im `serve
 Bei der API handelt es sich um eine REST-Schnittstelle welche mit dem JSON-Format arbeitet.
 
 ## Stundenplan
-Die Endpunkte zum Abfragen der Stundenpläne durch das Frontends sind in der Datei `controller/splus.ts` definiert.
+Die Endpunkte zum Abfragen der Stundenpläne durch das Frontend sind in der Datei `controller/splus.ts` definiert.
 
 ### GET `/splus/:timetable/:weeks`
 **Parameter:**
@@ -32,7 +32,7 @@ Die Endpunkte zum Abfragen der Stundenpläne durch das Frontends sind in der Dat
   * weeks: Eine oder mehrere durch Komma getrennte Kalenderwochen
 
 **Rückgabe:**
-  Liefert ein Timetable-Objekt (siehe `model/SplusEinsModel.ts`), welche alle Events (Verstanstaltungen) in diesem Plan in den angeforderten Wochen enthält.
+  Liefert ein Timetable-Objekt (siehe `model/SplusEinsModel.ts`), welche alle Events (Veranstaltungen) in diesem Plan in den angeforderten Wochen enthält.
 
 **Beispiel:**
   `/splus/informatik-wpf/33,34`
@@ -45,11 +45,21 @@ Die Endpunkte zum Abfragen der Stundenpläne durch das Frontends sind in der Dat
   * name: frei wählbarer Name für einen Stundenplan (für personalierte Pläne)
 
 **Rückgabe:**
-  Liefert ein Timetable-Objekt (siehe `model/SplusEinsModel.ts`), welche alle Events (Verstanstaltungen) oder falls übergeben, nur die angeforderten Veranstaltungen (lectures) enthält.
+  Liefert ein Timetable-Objekt (siehe `model/SplusEinsModel.ts`), welche alle Events (Veranstaltungen) oder falls übergeben, nur die angeforderten Veranstaltungen (lectures) enthält.
   Der Stundenplan hat den übergebenen Namen.
 
 **Beispiel:**
   `/splus/informatik-wpf,informatik-1/33,34/D123A,GA31R/MeinPlan`
+
+### GET `/splus/:timetable/lectures`
+**Parameter:**
+  * timetable: Stundenplan-ID wie in `assets/timetables.json`
+
+**Rückgabe:**
+  Liefert ein `Event`-Array (siehe `model/SplusEinsModel.ts`), welches aus den einzelnen Vorlesungen dieses Stundenplans besteht. Damit kann herausgefunden werden, welches und wie viele Module es in diesem Plan gibt. Wird im Frontend genutzt, um die Liste zum Personalisieren eines Plans bereitzustellen.
+
+**Beispiel:**
+  `/splus/informatik-wpf/lectures`
 
 ## ICS
 Der Endpunkt zum Abfragen der Stundenpläne im [iCalendar](https://de.wikipedia.org/wiki/ICalendar) Format für Kalender-Apps wie Outlook befindet sich in der Datei `controller/ics.ts`.

--- a/server/controllers/ics.ts
+++ b/server/controllers/ics.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto';
 
 import * as TIMETABLES from '../assets/timetables.json'; // TODO change this in SS21
 import { Event, TimetableRequest } from '../model/SplusEinsModel';
-import getEvents from '../lib/SplusApi';
+import { getEvents } from '../lib/SplusApi';
 
 const router = express.Router();
 const sha256 = (x) => createHash('sha256').update(x, 'utf8').digest('hex');

--- a/server/controllers/splus.ts
+++ b/server/controllers/splus.ts
@@ -3,7 +3,7 @@ import * as cors from 'cors';
 import * as TIMETABLES from '../assets/timetables.json'; // TODO change this in SS21
 
 import { TimetableRequest, TimetableMetadata, Timetable } from '../model/SplusEinsModel';
-import getEvents, { getUniqueEvents } from '../lib/SplusApi';
+import { getEvents, getUniqueEvents } from '../lib/SplusApi';
 
 const CACHE_SECONDS = parseInt(process.env.SPLUS_CACHE_SECONDS || '10800');
 
@@ -34,7 +34,8 @@ router.get('/:timetable/lectures', cors(), async (req, res, next) => {
   }
 
   try {
-    const request: TimetableRequest = <TimetableRequest> {
+    // Don't set week in request since it's not used anyway
+    const request: TimetableRequest = <TimetableRequest>{
       id: timetable.id,
       skedPath: timetable.skedPath,
       graphical: timetable.graphical,

--- a/server/controllers/splus.ts
+++ b/server/controllers/splus.ts
@@ -21,7 +21,7 @@ router.options('/:timetables/:weeks/:lectures?/:name', cors());
  * Get unique lectures for given timetable id
  *
  * @param timetable id
- * @return Timetable
+ * @return Array of unique events
  */
 router.get('/:timetable/lectures', cors(), async (req, res, next) => {
   const timetableId = req.params.timetable;
@@ -42,23 +42,8 @@ router.get('/:timetable/lectures', cors(), async (req, res, next) => {
     };
     const events = await getUniqueEvents(request);
 
-    const meta: TimetableMetadata = <TimetableMetadata> {
-      id: timetable.id,
-      faculty: timetable.faculty,
-      degree: timetable.degree,
-      specialisation: timetable.label,
-      semester: Number(timetable.semester)
-    };
-    const response: Timetable = <Timetable> {
-      name: timetable.degree == 'Räume' ?
-              `${timetable.semester} ${timetable.label}` :
-              `${(timetable.degree)} ${timetable.label} - ${timetable.semester}. Semester`,
-      events: events,
-      meta: meta,
-    };
-
     res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-    res.json(response);
+    res.json(events);
   } catch (error) {
     next(error);
   }

--- a/server/lib/SkedParser.ts
+++ b/server/lib/SkedParser.ts
@@ -5,7 +5,7 @@ import parseTable from './parseTable';
 
 moment.locale('de');
 
-export function parseSkedList(html: string, filterWeek: number) {
+export function parseSkedList(html: string): ParsedLecture[] {
   const $ = load(html);
 
   const events = [] as ParsedLecture[];
@@ -82,7 +82,7 @@ export function parseSkedList(html: string, filterWeek: number) {
       }
     }
 
-    if (!start.isValid() || !end.isValid() || start.isoWeek() != filterWeek % 52) {
+    if (!start.isValid() || !end.isValid()) {
       return;
     }
 
@@ -100,7 +100,7 @@ export function parseSkedList(html: string, filterWeek: number) {
   return events;
 }
 
-export function parseSkedGraphical(html: string, filterWeek: number, faculty: string) {
+export function parseSkedGraphical(html: string, faculty: string): ParsedLecture[]  {
   const $ = load(html);
   const events = [] as ParsedLecture[];
 
@@ -193,7 +193,7 @@ export function parseSkedGraphical(html: string, filterWeek: number, faculty: st
         const start = moment.tz(datum + ' ' + uhrzeit_0, dateFormat, 'Europe/Berlin');
         const end = moment.tz(datum + ' ' + uhrzeit_1, dateFormat, 'Europe/Berlin');
 
-        if (start.isoWeek() != filterWeek % 52) {
+        if (!start.isValid() || !end.isValid()) {
           return;
         }
 

--- a/server/lib/SplusApi.ts
+++ b/server/lib/SplusApi.ts
@@ -3,9 +3,7 @@ import * as cacheManager from 'cache-manager';
 import * as fsStore from 'cache-manager-fs-hash';
 import * as moment from 'moment';
 import { Event, TimetableRequest } from '../model/SplusEinsModel';
-import { ParsedLecture } from '../model/SplusModel';
 import { parseSkedGraphical, parseSkedList } from './SkedParser';
-import { eventNames } from 'process';
 
 const SKED_BASE = 'https://stundenplan.ostfalia.de/';
 
@@ -83,7 +81,6 @@ async function parseTimetable(timetable: TimetableRequest): Promise<Event[]> {
 
 export async function getUniqueEvents(timetable: TimetableRequest): Promise<Event[]> {
   // Disable week field
-  timetable.week = null;
   const allEvents = await parseTimetable(timetable);
   // Filter all unique events
   const uniqueEvents = [...new Set(allEvents.map(obj => obj.id))] // search all unique IDs

--- a/web/components/custom-timetable-dialog.vue
+++ b/web/components/custom-timetable-dialog.vue
@@ -97,8 +97,8 @@
 
 <script>
 import { mapMutations, mapGetters, mapState } from 'vuex';
-import { range, uniq, flatten, customTimetableToRoute } from '../lib/util';
-import { loadEvents, eventsAsLectures } from '../store/splus';
+import { uniq, flatten, customTimetableToRoute } from '../lib/util';
+import { loadUniqueLectures, eventsAsLectures } from '../store/splus';
 import TimetableSelect from './timetable-select.vue';
 import CourseMultiselect from './course-multiselect.vue';
 import CustomTimetableCookieReminder from './custom-timetable-cookie-reminder.vue'
@@ -211,13 +211,9 @@ export default {
       this.loading = true;
 
       try {
-        const weeks = range(this.weekOrDefault - 1, this.weekOrDefault + 5);
-        const events = await Promise.all(weeks.map((week) =>
-          loadEvents(schedule, week, this.$axios.$get)));
-        const lectures = eventsAsLectures(flatten(events));
-        const uniqueLectures = lectures
-          .filter((lecture, index, self) => self.indexOf(lecture) == index);
-        this.$set(this.lectures, schedule.id, uniqueLectures);
+        const events = await loadUniqueLectures(schedule, this.$axios.$get);
+        const lectures = eventsAsLectures(events);
+        this.$set(this.lectures, schedule.id, lectures);
       } catch (error) {
         this.enqueueError('Stundenplan: API-Verbindung fehlgeschlagen');
         console.error('error during API call', error.message);

--- a/web/store/splus.js
+++ b/web/store/splus.js
@@ -37,6 +37,13 @@ export async function loadEvents(timetable, weeks, $get) {
 }
 
 /**
+ * Return all unique lectures for the given timetable.
+ */
+export async function loadUniqueLectures(timetable, $get) {
+  return await $get(`/api/splus/${timetable.id}/lectures`);
+}
+
+/**
  * Transform v2 events to v1 lectures.
  */
 export function eventsAsLectures(events) {


### PR DESCRIPTION
* New endpoint for loading unique lectures metadata for a single timetable, fixes #449. Also has the advantage that past semester events are still available for selection in the dialog. 

* Improve caching: Store the parsed events instead of storing only the raw response. Improves responsiveness **after** first load by a lot. First load (without cache) stays approximately equal (or a few milliseconds slower).
Timing measurements in backend (Handel und Logistik 1. Semester PO 2018, 193 lectures total):

|    |      Old version      |  New version |
|----------|-------------|------|
| average (5 runs) of first load without cache | 620 ms |  650 ms |
| average (5 runs) of loads with cache |    380 ms   |   10 ms |

This makes switching between weeks more responsive than before.