### PR TITLE
New informatik timetables with CSV

### DIFF
--- a/docs/semesterbeginn.md
+++ b/docs/semesterbeginn.md
@@ -22,7 +22,7 @@ Diese müssen folgende Struktur besitzen:
     "degree": "Bachelor of Science",
     "semester": "1",
     "raumplan": false,
-    "graphical": false,
+    "type": "list",
     "skedPath": "i/Semester/Semester-Liste/I-B.Sc. Informatik 1. Sem.html"
   }
 ```
@@ -32,7 +32,7 @@ Diese müssen folgende Struktur besitzen:
 * `degree` gibt den angestrebten Studienabschluss an
 * `semester` gibt über­ra­schen­der­wei­se das Semester an
 * `raumplan` ist ein Boolean-Wert welcher angibt, ob es sich um einen Raumplan handelt
-* `graphical` ist ein Boolean-Wert welcher angibt, ob es sich um einen `grafischen Plan` handelt (bei `false` handelt es sich um einen `Listenplan`)
+* `type` ist ein String welcher angibt, ob es sich um einen grafischen Plan (`graphical`, der häufigste Fall), einen Listenplan (`list`) oder einen CSV-Plan handelt (`csv`)
 * `skedPath` gibt den Pfad an, über welchen der Plan in der Sked Anwendung abgerufen werden kann (z.B. `http://stundenplan.ostfalia.de/i/Semester/Semester-Liste/I-B.Sc. Informatik 1. Sem.html`)
 
 Siehe auch [Erklärungen zum serverseitigen Parser](./server.md#parser).

--- a/docs/server.md
+++ b/docs/server.md
@@ -114,10 +114,11 @@ Die Endpunkte zum Abfragen der News-Daten befinden sich in der Datei `controller
 ## Parser
 Der Parser für die Stundenpläne von sked befindet sich im Verzeichnis des Servers unter `/lib/SkedParser.ts`.
 
-In Sked gibt es grundsätzlich zwei verschiedene Arten von Stundenplänen. Zum einen `Listenpläne` (Auflistung der Module) und zum anderen `grafische Pläne` (anschauliche Darstellung).
-Für beide Versionen hat der Parser eine Implementierung da es für manche Studiengänge manchmal nur eine der beiden gibt.
-Sie Funktionen heißen `parseSkedList` und `parseSkedGraphical`. Diese erhalten als Übergabeparameter das HTML der Stundenplanseite als String und die gewünschte Woche als Zahl.
-Mit Hilfe der Bibliothek [cheerio](https://cheerio.js.org/) kann auf die einzelnen Tags des HTML zugegriffen werden. Sie bildet die Grundlage des Parsers.
+In Sked gibt es grundsätzlich drei verschiedene Arten von Stundenplänen. `Listenpläne` als Auflistung der Module, `grafische Pläne` als anschauliche Darstellung (einem Stundenplan nachempfunden) und `CSV-Pläne` (der Fakultät Informatik).
+Für alle Versionen hat der Parser eine Implementierung, da es für manche Studiengänge nicht alle Formen gibt. 
+
+Die HTML-Parser Funktionen sind `parseSkedList` und `parseSkedGraphical`. Diese erhalten als Übergabeparameter das HTML der Stundenplanseite als String.
+Mithilfe der Bibliothek [cheerio](https://cheerio.js.org/) kann auf die einzelnen Tags des HTML zugegriffen werden. Sie bildet die Grundlage des HTML-Parsers.
 
 In beiden Implementierung wird so der Quelltext der Pläne nach den nötigen Informationen durchsucht.
 Leider sind nicht alle Pläne gleich aufgebaut:
@@ -126,4 +127,6 @@ Leider sind nicht alle Pläne gleich aufgebaut:
 
 Beschäftigt man sich mit dem Parser muss man diese Punkte **zwangsläufig** beachten.
 
-Beide Implementierung des Parser liefern eine Liste vom Interface *ParsedLecture* zurück wie es in `/model/SplusModel.ts` definiert ist.
+`parseSkedCSV` ist die Funktion für das CSV, hier wird lediglich das CSV eingelesen und anhand der Spaltenüberschriften zugeordnet. Diese Methode ist bevorzugt, da sie am wenigstens Fehler erzeugt.
+
+Alle Implementierung der Parser liefern eine Liste vom Interface *ParsedLecture* zurück, wie es in `/model/SplusModel.ts` definiert ist.

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -468,38 +468,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%201.%20Sem..csv",
-    "label": "Digital Technologies",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_digital_technologies_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Informatik%201.%20Sem.csv",
     "label": "Informatik",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_informatik_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%201.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%201.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
@@ -585,15 +558,6 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%203.%20Sem..csv",
-    "label": "Digital Technologies",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_digital_technologies_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%203.%20Sem.%20(PO18).csv",
     "label": "IE (PO18)",
     "faculty": "Informatik",
@@ -621,47 +585,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO13).csv",
-    "label": "SYE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_sye_po13_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO18).csv",
     "label": "SYE (PO18)",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_sye_po18_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%203.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%203.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%203.%20Sem..csv",
-    "label": "WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_wi_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
@@ -684,29 +612,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO13).csv",
-    "label": "IE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_ie_po13_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO18).csv",
     "label": "IE (PO18)",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_ie_po18_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/IT-Management_4_4.%20Sem..csv",
-    "label": "IT-Management_4",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_it_management_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
@@ -729,15 +639,6 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO13).csv",
-    "label": "SYE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_sye_po13_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO18).csv",
     "label": "SYE (PO18)",
     "faculty": "Informatik",
@@ -748,7 +649,7 @@
   },
   {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI_4_4.%20Sem..csv",
-    "label": "WI_4",
+    "label": "WI",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_wi_4_ss21",
@@ -801,48 +702,12 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%205.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%205.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%205.%20Sem..csv",
     "label": "WI",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_wi_5_ss21",
     "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%206.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%206.%20Sem..csv",
-    "label": "WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_wi_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
@@ -871,42 +736,6 @@
     "id": "i_alle_wpf_ss21",
     "semester": "WPF",
     "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
-    "label": "VFH-MI Wahlpflichtfaecher_1",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_wahlpflichtfaecher_1_1_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/VFH-WI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
-    "label": "VFH-WI Wahlpflichtfaecher_1",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_wahlpflichtfaecher_1_1_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%201.%20Sem..csv",
-    "label": "VFH-M.Sc. WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_m_wi_1_ss21",
-    "semester": 1,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%203.%20Sem..csv",
-    "label": "VFH-M.Sc. WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_m_wi_3_ss21",
-    "semester": 3,
-    "degree": "Master"
   },
   {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/M.Sc.%20Informatik%20(Alle%20Sem.+Schwerpunkte).csv",

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -1,81 +1,108 @@
 [
   {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html",
-    "label": "EIT(iP)-IT",
+    "skedPath": "e/semester/E-EIT-GS-Sem1.html",
+    "label": "EIT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_6_ss21",
-    "semester": 6,
+    "type": "graphical",
+    "id": "e_eit_gs_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-WEIT-Sem1.html",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT-GS-Sem2.html",
+    "label": "EIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_gs_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EITiP-GS-Sem2.html",
+    "label": "EITiP",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eitip_gs_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-WEIT-Sem2.html",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-WEITiP-Sem2.html",
     "label": "WEITiP",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_weitip_2_ss21",
     "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT-GS-Sem1.html",
-    "label": "EIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_gs_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html",
-    "label": "EIT(iP)-AT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_at_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html",
     "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_gs_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html",
+    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html",
     "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_6_ss21",
-    "semester": 6,
+    "type": "graphical",
+    "id": "e_weit_ip_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html",
+    "label": "EIT(iP)-AT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_at_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html",
-    "label": "WEIT(iP)",
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_5_ss21",
-    "semester": 5,
+    "type": "graphical",
+    "id": "e_eit_ip_it_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-WEIT(iP)-Sem4.html",
     "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_weit_ip_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
@@ -84,268 +111,160 @@
     "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html",
     "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_at_5_ss21",
     "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-WEIT-Sem1.html",
-    "label": "WEIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-IMES-VZ.html",
-    "label": "IMES Vollzeit",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_imes_vz_ss21",
-    "semester": "Sonstige",
-    "degree": "Master"
-  },
-  {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html",
-    "label": "WEIT(iP)",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EITiP-GS-Sem2.html",
-    "label": "EITiP",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eitip_gs_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html",
-    "label": "EIT(iP)-IT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html",
-    "label": "EIT(iP)-AT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_at_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html",
-    "label": "EIT(iP)-IT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT-GS-Sem2.html",
-    "label": "EIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_gs_2_ss21",
-    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_5_ss21",
     "semester": 5,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-IMES-TZ.html",
-    "label": "IMES Teilzeit",
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_imes_tz_ss21",
-    "semester": "Sonstige",
-    "degree": "Master"
+    "type": "graphical",
+    "id": "e_eit_ip_it_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT-Sem2.html",
-    "label": "WEIT",
+    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_2_ss21",
-    "semester": 2,
+    "type": "graphical",
+    "id": "e_weit_ip_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html",
+    "label": "EIT(iP)-AT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_at_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/IVG2_SOSE2021.html",
-    "label": "IVG",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_ivg_2_ss21",
-    "semester": 2,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html",
+    "label": "EIT(iP)-IT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_it_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/APIP5_SOSE2021.html",
-    "label": "APIP",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_apip_5_ss21",
-    "semester": 5,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html",
+    "label": "WEIT(iP)",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_ip_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/MAG2_A1_SOSE2021.html",
-    "label": "MAG - Gruppe A1",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_a1_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
+    "skedPath": "e/semester/E-IMES-TZ.html",
+    "label": "IMES Teilzeit",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_imes_tz_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
   },
   {
-    "skedPath": "g/wp/APIP7_SOSE2021.html",
-    "label": "APIP",
+    "skedPath": "e/semester/E-IMES-VZ.html",
+    "label": "IMES Vollzeit",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_imes_vz_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
+  },
+  {
+    "skedPath": "g/wp/APP1_SOSE2021.html",
+    "label": "APP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_apip_7_ss21",
-    "semester": 7,
+    "type": "graphical",
+    "id": "g_app_1_ss21",
+    "semester": 1,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMP1_SOSE2021.html",
     "label": "BMP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_1_ss21",
     "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG2_B1_SOSE2021.html",
-    "label": "MAG - Gruppe B1",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_b1_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_KH_SOSE2021.html",
-    "label": "MAG - Schwerpunkt KH",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_kh_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/BMR3_M_SOSE2021.html",
-    "label": "BMR - Studienprofil M",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_bmr_m_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/APP1_SOSE2021.html",
-    "label": "APP",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_app_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/PM6_M_SOSE2021.html",
-    "label": "PM - Studienprofil M",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_pm_m_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/WPF_APB6_SOSE2021.html",
-    "label": "WPF APB 6. und höhere Sem.",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_wpf_apb6_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG2_A2_SOSE2021.html",
-    "label": "MAG - Gruppe A2",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_a_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_PH_SOSE2021.html",
-    "label": "MAG - Schwerpunkt PH",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_ph_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/WPF_MIG6_SOSE2021.html",
-    "label": "WPF MIG 6. und höhere Sem.",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_wpf_mig6_ss21",
-    "semester": "WPF",
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMR1_SOSE2021.html",
     "label": "BMR",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmr_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/BMR3_B_SOSE2021.html",
-    "label": "BMR - Studienprofil B",
+    "skedPath": "g/wp/IVG2_SOSE2021.html",
+    "label": "IVG",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_bmr_b_3_ss21",
-    "semester": 3,
+    "type": "graphical",
+    "id": "g_ivg_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_A1_SOSE2021.html",
+    "label": "MAG - Gruppe A1",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_a1_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_A2_SOSE2021.html",
+    "label": "MAG - Gruppe A2",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_a_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_B1_SOSE2021.html",
+    "label": "MAG - Gruppe B1",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_b1_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/MAG2_B2_SOSE2021.html",
     "label": "MAG - Gruppe B2",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_mag_b_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
@@ -354,34 +273,16 @@
     "skedPath": "g/wp/APP3_SOSE2021.html",
     "label": "APP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_app_3_ss21",
     "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_KV_SOSE2021.html",
-    "label": "MAG - Schwerpunkt KV",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_kv_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/PM6_B_SOSE2021.html",
-    "label": "PM - Studienprofil B",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_pm_b_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMP3_B_SOSE2021.html",
     "label": "BMP - Studienprofil B",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_b_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
@@ -390,70 +291,124 @@
     "skedPath": "g/wp/BMP3_M_SOSE2021.html",
     "label": "BMP - Studienprofil M",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_m_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "h/wp/h_stdgrp_hul_4.html",
-    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_hul_4_ss21",
+    "skedPath": "g/wp/BMR3_B_SOSE2021.html",
+    "label": "BMR - Studienprofil B",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_bmr_b_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/BMR3_M_SOSE2021.html",
+    "label": "BMR - Studienprofil M",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_bmr_m_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_KH_SOSE2021.html",
+    "label": "MAG - Schwerpunkt KH",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_kh_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_KV_SOSE2021.html",
+    "label": "MAG - Schwerpunkt KV",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_kv_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_PH_SOSE2021.html",
+    "label": "MAG - Schwerpunkt PH",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_ph_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/APIP5_SOSE2021.html",
+    "label": "APIP",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_apip_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/PM6_B_SOSE2021.html",
+    "label": "PM - Studienprofil B",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_pm_b_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/PM6_M_SOSE2021.html",
+    "label": "PM - Studienprofil M",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_pm_m_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/APIP7_SOSE2021.html",
+    "label": "APIP",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_apip_7_ss21",
+    "semester": 7,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/WPF_APB6_SOSE2021.html",
+    "label": "WPF APB 6. und höhere Sem.",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_wpf_apb6_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/WPF_MIG6_SOSE2021.html",
+    "label": "WPF MIG 6. und höhere Sem.",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_wpf_mig6_ss21",
+    "semester": "WPF",
     "degree": "Bachelor"
   },
   {
     "skedPath": "h/wp/h_stdgrp_hul_2.html",
     "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_hul_2_ss21",
     "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_hul_6.html",
-    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_hul_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_5.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_6.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_4.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_4_ss21",
-    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "h/wp/h_stdgrp_soa_2.html",
     "label": "Soziale Arbeit",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_soa_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
@@ -462,89 +417,53 @@
     "skedPath": "h/wp/h_stdgrp_soa_3.html",
     "label": "Soziale Arbeit",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_soa_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-B-WR_2_2. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_wr_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-RPP_2_2. Sem..html",
-    "label": "Recht, Personalmangement und Psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_rpp_2_ss21",
-    "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-B-RPP_2_2. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rpp_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-B-RPP_1_1. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rpp_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-RPP_4_4. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_4_ss21",
+    "skedPath": "h/wp/h_stdgrp_hul_4.html",
+    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_hul_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RFS_3_3. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_3_ss21",
-    "semester": 3,
+    "skedPath": "h/wp/h_stdgrp_soa_4.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-B-RFS_2_2. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rfs_2_ss21",
-    "semester": 2,
+    "skedPath": "h/wp/h_stdgrp_soa_5.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_5_ss21",
+    "semester": 5,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-WR_6_6. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wr_6_ss21",
+    "skedPath": "h/wp/h_stdgrp_hul_6.html",
+    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_hul_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RPP_6_6. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_6_ss21",
+    "skedPath": "h/wp/h_stdgrp_soa_6.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
@@ -552,8 +471,17 @@
     "skedPath": "r/studentenset/R-B-RFS_1_1. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_b_rfs_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-B-RPP_1_1. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_b_rpp_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
@@ -561,133 +489,277 @@
     "skedPath": "r/studentenset/R-B-WR_1_1. Sem..html",
     "label": "Wirtschaftsrecht",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_b_wr_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/Erstsemesterveranstaltungen_4_4. Sem..html",
-    "label": "Erstsemesterveranstaltungen",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_erstsemesterveranstaltungen_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-WPF-WF-Tutorien_4_4. Sem..html",
-    "label": "Wahlpflichtfächer SoSe 2021",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wpf_wf_tutorien_4_4_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-RFS_4_4. Sem..html",
+    "skedPath": "r/studentenset/R-B-RFS_2_2. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-Gremien und Sitzungen Aktuell.html",
-    "label": "Gremien und Sitzungen",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_gremien_und_sitzungen_aktuell_ss21",
-    "semester": "Sonstige",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-FTC_2_2. Sem..html",
-    "label": "Finance, Tax and Company Law",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_ftc_2_ss21",
+    "type": "graphical",
+    "id": "r_b_rfs_2_ss21",
     "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-WR_3_3. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wr_3_ss21",
-    "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RFS_6_6. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-ILB_2_2. Sem..html",
-    "label": "International Law and Business",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_ilb_2_ss21",
-    "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-RPP_3_3. Sem..html",
+    "skedPath": "r/studentenset/R-B-RPP_2_2. Sem..html",
     "label": "Personalmanagement und -psychologie",
     "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_3_ss21",
-    "semester": 3,
+    "type": "graphical",
+    "id": "r_b_rpp_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-B-WR_2_2. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_b_wr_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "r/studentenset/R-Exkursionen_3_3. Sem..html",
     "label": "Exkursionen (derzeit finden keine Exkursionen statt)",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_exkursionen_3_ss21",
     "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_3_3. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_3_3. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WR_3_3. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wr_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/Erstsemesterveranstaltungen_4_4. Sem..html",
+    "label": "Erstsemesterveranstaltungen",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_erstsemesterveranstaltungen_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_4_4. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_4_4. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "r/studentenset/R-WR_4_4. Sem..html",
     "label": "Wirtschaftsrecht",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_wr_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_6_6. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_6_6. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WR_6_6. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wr_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-Gremien und Sitzungen Aktuell.html",
+    "label": "Gremien und Sitzungen",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_gremien_und_sitzungen_aktuell_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WPF-WF-Tutorien_4_4. Sem..html",
+    "label": "Wahlpflichtfächer SoSe 2021",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wpf_wf_tutorien_4_4_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-FTC_2_2. Sem..html",
+    "label": "Finance, Tax and Company Law",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_ftc_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-ILB_2_2. Sem..html",
+    "label": "International Law and Business",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_ilb_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-RPP_2_2. Sem..html",
+    "label": "Recht, Personalmangement und Psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_rpp_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_1_1. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Berufsanerkennungsjahr_1_1. Sem.html",
+    "label": "Berufsanerkennungsjahr SoSe 21",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_berufsanerkennungsjahr_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/S-Fakultaetstermine_1_1. Sem.html",
+    "label": "Fakultätstermine SS 2021 - Gremienzeiten",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_fakultaetstermine_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Weiterbindlung Erlebnispaedagogok_1_1. Sem.html",
+    "label": "Weiterbindlung Erlebnispädagogok",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_weiterbindlung_erlebnispaedagogok_1_ss21",
+    "semester": 1,
     "degree": "Bachelor"
   },
   {
     "skedPath": "s/wp/Bachelor Soziale Arbeit_2_2. Sem.html",
     "label": "Bachelor",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "s/wp/MA MSM_4_4. Sem.html",
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_3_3. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_4_4. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_5_5. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_6_6. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/MA MSM_1_1. Sem.html",
     "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_4_ss21",
-    "semester": 4,
+    "type": "graphical",
+    "id": "s_ma_msm_1_ss21",
+    "semester": 1,
     "degree": "Master"
   },
   {
     "skedPath": "s/wp/MA 2020 PSA_1_1. Sem.html",
     "label": "Master Präventive - Schwerpunkt 1",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_2020_psa_1_ss21",
     "semester": 1,
     "degree": "Master"
@@ -696,142 +768,25 @@
     "skedPath": "s/wp/MA PSA_1_1. Sem. - Schwerpunkt 1.html",
     "label": "Master Präventive - Schwerpunkt 2",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_1_ss21",
     "semester": 1,
     "degree": "Master"
   },
   {
-    "skedPath": "s/wp/MA PSA_3. Semester_Schwerpunkt 2.html",
-    "label": "Master Präventive - Schwerpunkt 2",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_psa_schwerpunkt_2_3_ss21",
-    "semester": 3,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Berufsanerkennungsjahr_1_1. Sem.html",
-    "label": "Berufsanerkennungsjahr SoSe 21",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_berufsanerkennungsjahr_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/MA MSM_1_1. Sem.html",
-    "label": "Fernstudiengang Master Sozialmanagement",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_1_ss21",
-    "semester": 1,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Weiterbindlung Erlebnispaedagogok_1_1. Sem.html",
-    "label": "Weiterbindlung Erlebnispädagogok",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_weiterbindlung_erlebnispaedagogok_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 2.html",
-    "label": "Master Präventive - Schwerpunkt 2",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_2_4_ss21",
-    "semester": 4,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_5_5. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_3_3. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 1.html",
-    "label": "Master Präventive - Schwerpunkt 1",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_1_4_ss21",
-    "semester": 4,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_4_4. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "s/wp/MA MSM_2_2. Sem.html",
     "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_msm_2_ss21",
     "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/S-Fakultaetstermine_1_1. Sem.html",
-    "label": "Fakultätstermine SS 2021 - Gremienzeiten",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_fakultaetstermine_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/MA MSM_3_3. Sem.html",
-    "label": "Fernstudiengang Master Sozialmanagement",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_3_ss21",
-    "semester": 3,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_6_6. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_3. Sem._Schwerpunkt 1.html",
-    "label": "Master Präventive - Schwerpunkt 1",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_1_3_ss21",
-    "semester": 3,
     "degree": "Master"
   },
   {
     "skedPath": "s/wp/MA PSA_2_2. Sem. - Schwerpunkt 2_Kopie.html",
     "label": "Master Präventive - Schwerpunkt 1",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_kopie_2_ss21",
     "semester": 2,
     "degree": "Master"
@@ -840,97 +795,205 @@
     "skedPath": "s/wp/MA PSA_2_Schwerpunkt 1.html",
     "label": "Master Präventive - Schwerpunkt 2",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_1_2_ss21",
     "semester": 2,
     "degree": "Master"
   },
   {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_1_1. Sem.html",
-    "label": "Bachelor",
+    "skedPath": "s/wp/MA MSM_3_3. Sem.html",
+    "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_1_ss21",
+    "type": "graphical",
+    "id": "s_ma_msm_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_3. Sem._Schwerpunkt 1.html",
+    "label": "Master Präventive - Schwerpunkt 1",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_1_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/MA PSA_3. Semester_Schwerpunkt 2.html",
+    "label": "Master Präventive - Schwerpunkt 2",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_ma_psa_schwerpunkt_2_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/MA MSM_4_4. Sem.html",
+    "label": "Fernstudiengang Master Sozialmanagement",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_ma_msm_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 1.html",
+    "label": "Master Präventive - Schwerpunkt 1",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_1_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 2.html",
+    "label": "Master Präventive - Schwerpunkt 2",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_2_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/BEE_2020_SoSe_1_1. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_2020_1_ss21",
     "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/EGT_2020_SoSe_1_1. Sem..html",
+    "label": "EGT / EGTiP",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_2020_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/ge/GE_1_1. Sem..html",
+    "label": "Green Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_ge_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/sce/SCE_1_1. Sem..html",
+    "label": "Smart City Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_sce_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_1_1. Sem..html",
+    "label": "WING E",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/WING Umwelt_2020_SoSe_1_1. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_2020_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_2_2. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/dt/Digital Technologies (DT Energie)_2_2. Sem..html",
+    "label": "DT Energie",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_digital_technologies_dt_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_2_2. Sem..html",
+    "label": "EGT / EGTiP",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/ge/Green Engineering_2_2. Sem..html",
+    "label": "Green Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_green_engineering_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/sce/Smart City Engineering_2_2. Sem..html",
+    "label": "Smart City Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_smart_city_engineering_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_2_2. Sem..html",
+    "label": "WING E",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_2_2. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_u_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_4_4. Sem..html",
     "label": "BEE",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_bee_4_ss21",
     "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_6_6. Sem..html",
-    "label": "BEE",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_bee_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem..html",
-    "label": "EGT / EGTiP ÖIV",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. TGA.html",
-    "label": "EGT / EGTiP PO13",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_tga_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_4_4. Sem..html",
     "label": "EGT / EGTiP",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_egt_egtip_4_ss21",
     "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. OeIV.html",
-    "label": "EGT / EGTiP TGA",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_oeiv_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_6_6. Sem..html",
-    "label": "WING U",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_wing_u_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_6_6. Semester.html",
-    "label": "WING E (PO 2018)",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_wing_e_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_4_4. Sem..html",
     "label": "WING E",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_wing_e_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
@@ -939,9 +1002,63 @@
     "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_4_4. Sem..html",
     "label": "WING U",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_wing_u_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_6_6. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. TGA.html",
+    "label": "EGT / EGTiP PO13",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_tga_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. OeIV.html",
+    "label": "EGT / EGTiP TGA",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_oeiv_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem..html",
+    "label": "EGT / EGTiP ÖIV",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_6_6. Semester.html",
+    "label": "WING E (PO 2018)",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_6_6. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_u_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   }
 ]

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -855,6 +855,294 @@
     "degree": "Master"
   },
   {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_2.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lom_2.html",
+    "label": "Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lom_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lop_2.html",
+    "label": "Logistikmanagement im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lop_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_md_2.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_md_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mk_2.html",
+    "label": "Medienkommunikation",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mk_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mm_2.html",
+    "label": "Medienmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mpm_2.html",
+    "label": "Mobilität und Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mpm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_spm_2.html",
+    "label": "Sportmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_spm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_srm_2.html",
+    "label": "Stadt- und Regionalmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_srm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tm_2.html",
+    "label": "Tourismusmangement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wmv_2.html",
+    "label": "Wirtschaftsingenieurwesen Mobilität und Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wmv_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_4.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_md_4.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_md_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mk_4.html",
+    "label": "Medienkommunikation",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mk_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mm_4.html",
+    "label": "Medienmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_pvm_4.html",
+    "label": "Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_pvm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_spm_4.html",
+    "label": "Sportmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_spm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_srm_4.html",
+    "label": "Stadt- und Regionalmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_srm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tm_4.html",
+    "label": "Tourismusmangement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tlm_4.html",
+    "label": "Transport- und Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tlm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wiv_4.html",
+    "label": "Wirtschaftsingenieurwesen Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wiv_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lip_4.html",
+    "label": "Logistik im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lip_4_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_6.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_pvm_6.html",
+    "label": "Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_pvm_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tlm_6.html",
+    "label": "Transport- und Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tlm_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wiv_6.html",
+    "label": "Wirtschaftsingenieurwesen Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wiv_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lip_8.html",
+    "label": "Logistik im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lip_8_ss21",
+    "semester": 8,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_mvl_1.html",
+    "label": "Verkehr und Logistik",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_mvl_1_ss21",
+    "semester": 1,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_fdu_2.html",
+    "label": "Führung in Dienstleistungsunternehmen",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_fdu_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_km_2.html",
+    "label": "Kommunikationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_km_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_fdu_4.html",
+    "label": "Führung in Dienstleistungsunternehmen",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_fdu_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_km_4.html",
+    "label": "Kommunikationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_km_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
     "skedPath": "v/stundenplan/bee/BEE_2020_SoSe_1_1. Sem..html",
     "label": "BEE",
     "faculty": "Versorgungstechnik",

--- a/server/assets/timetables.json
+++ b/server/assets/timetables.json
@@ -468,6 +468,456 @@
     "degree": "Bachelor"
   },
   {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%201.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Informatik%201.%20Sem.csv",
+    "label": "Informatik",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_informatik_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%201.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%201.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%201.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%202.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%202.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%202.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%202.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%202.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%202.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%202.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%203.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%203.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%203.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%203.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%203.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO13).csv",
+    "label": "SYE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po13_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%203.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%203.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%203.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%204.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%204.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO13).csv",
+    "label": "IE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po13_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/IT-Management_4_4.%20Sem..csv",
+    "label": "IT-Management_4",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_it_management_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%204.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%204.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO13).csv",
+    "label": "SYE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po13_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI_4_4.%20Sem..csv",
+    "label": "WI_4",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%205.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%205.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%205.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%205.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%205.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%205.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%205.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%205.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%206.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%206.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Career%20Service.csv",
+    "label": "Career Service",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_career_service_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Sprachenzentrum.csv",
+    "label": "Sprachenzentrum",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sprachenzentrum_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Alle%20WPF.csv",
+    "label": "Alle WPF",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_alle_wpf_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
+    "label": "VFH-MI Wahlpflichtfaecher_1",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_wahlpflichtfaecher_1_1_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/VFH-WI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
+    "label": "VFH-WI Wahlpflichtfaecher_1",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_wahlpflichtfaecher_1_1_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%201.%20Sem..csv",
+    "label": "VFH-M.Sc. WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_m_wi_1_ss21",
+    "semester": 1,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%203.%20Sem..csv",
+    "label": "VFH-M.Sc. WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_m_wi_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/M.Sc.%20Informatik%20(Alle%20Sem.+Schwerpunkte).csv",
+    "label": "M.Sc. Informatik (Alle Sem.+Schwerpunkte)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_m_informatik_alle_schwerpunkte_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
+  },
+  {
     "skedPath": "r/studentenset/R-B-RFS_1_1. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
@@ -887,6 +1337,15 @@
     "faculty": "Verkehr-Sport-Tourismus-Medien",
     "type": "graphical",
     "id": "k_md_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mdma_2.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mdma_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
   },

--- a/server/controllers/ics.ts
+++ b/server/controllers/ics.ts
@@ -64,7 +64,7 @@ router.get('/:version/:timetables/:lectures?', async (req, res, next) => {
     weeks.forEach((week) => timetables.forEach((timetable) => requests.push(<TimetableRequest>{
       id: timetable.id,
       week: week,
-      graphical: timetable.graphical,
+      type: timetable.type,
       faculty: timetable.faculty,
       skedPath: timetable.skedPath
     })));

--- a/server/controllers/splus.ts
+++ b/server/controllers/splus.ts
@@ -37,8 +37,8 @@ router.get('/:timetable/lectures', async (req, res, next) => {
     const request: TimetableRequest = <TimetableRequest>{
       id: timetable.id,
       skedPath: timetable.skedPath,
-      graphical: timetable.graphical,
-      faculty: timetable.faculty
+      faculty: timetable.faculty,
+      type: timetable.type
     };
     const events = await getUniqueEvents(request);
 
@@ -76,8 +76,8 @@ router.get('/:timetable/:weeks', async (req, res, next) => {
       id: timetable.id,
       week: week,
       skedPath: timetable.skedPath,
-      graphical: timetable.graphical,
-      faculty: timetable.faculty
+      faculty: timetable.faculty,
+      type: timetable.type
     }));
     const events = await getEvents(requests);
 
@@ -140,8 +140,8 @@ router.get('/:timetables/:weeks/:lectures?/:name', async (req, res, next) => {
       id: timetable.id,
       week: week,
       skedPath: timetable.skedPath,
-      graphical: timetable.graphical,
-      faculty: timetable.faculty
+      faculty: timetable.faculty,
+      type: timetable.type
     }))));
     const allEvents = await getEvents(requests);
     const filteredEvents = titleIds.length > 0

--- a/server/lib/SkedParser.ts
+++ b/server/lib/SkedParser.ts
@@ -162,6 +162,11 @@ export function parseSkedCSV (csvString: string): ParsedLecture[] {
     if (!start.isValid() || !end.isValid()) {
       return;
     }
+    if (veranstaltung === 'Information') {
+      // Ganztägige Informationsevents Fakultät I entfernen, da die im Kalender sehr schlecht aussehen
+      // todo ws21 diesen if-block entfernen, das ist nur ein workaround für ss21
+      return;
+    }
 
     events.push({
       info: anmerkung,

--- a/server/model/SplusEinsModel.ts
+++ b/server/model/SplusEinsModel.ts
@@ -18,8 +18,8 @@ export interface TimetableRequest {
   id: string;
   week: number;
   skedPath: string;
-  graphical: boolean;
-  faculty: string
+  faculty: string;
+  type: string
 }
 
 export interface EventMetadata {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
+        "csv-string": "^4.0.1",
         "express": "^4.17.1",
         "hafas-client": "^5.15.0",
         "ical-generator": "^1.15.4",
@@ -5844,6 +5845,14 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
+    },
+    "node_modules/csv-string": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.0.1.tgz",
+      "integrity": "sha512-nCdK+EWDbqLvZ2MmVQhHTmidMEsHbK3ncgTJb4oguNRpkmH5OOr+KkDRB4nqsVrJ7oK0AdO1QEsBp0+z7KBtGQ==",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -21612,6 +21621,11 @@
           "dev": true
         }
       }
+    },
+    "csv-string": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.0.1.tgz",
+      "integrity": "sha512-nCdK+EWDbqLvZ2MmVQhHTmidMEsHbK3ncgTJb4oguNRpkmH5OOr+KkDRB4nqsVrJ7oK0AdO1QEsBp0+z7KBtGQ=="
     },
     "cyclist": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
+    "csv-string": "^4.0.1",
     "express": "^4.17.1",
     "hafas-client": "^5.15.0",
     "ical-generator": "^1.15.4",

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -468,38 +468,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%201.%20Sem..csv",
-    "label": "Digital Technologies",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_digital_technologies_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Informatik%201.%20Sem.csv",
     "label": "Informatik",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_informatik_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%201.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%201.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
@@ -585,15 +558,6 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%203.%20Sem..csv",
-    "label": "Digital Technologies",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_digital_technologies_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%203.%20Sem.%20(PO18).csv",
     "label": "IE (PO18)",
     "faculty": "Informatik",
@@ -621,47 +585,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO13).csv",
-    "label": "SYE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_sye_po13_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO18).csv",
     "label": "SYE (PO18)",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_sye_po18_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%203.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%203.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%203.%20Sem..csv",
-    "label": "WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_wi_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
@@ -684,29 +612,11 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO13).csv",
-    "label": "IE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_ie_po13_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO18).csv",
     "label": "IE (PO18)",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_ie_po18_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/IT-Management_4_4.%20Sem..csv",
-    "label": "IT-Management_4",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_it_management_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
@@ -729,15 +639,6 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO13).csv",
-    "label": "SYE (PO13)",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_sye_po13_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO18).csv",
     "label": "SYE (PO18)",
     "faculty": "Informatik",
@@ -748,7 +649,7 @@
   },
   {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI_4_4.%20Sem..csv",
-    "label": "WI_4",
+    "label": "WI",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_wi_4_ss21",
@@ -801,48 +702,12 @@
     "degree": "Bachelor"
   },
   {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%205.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%205.%20Sem..csv",
-    "label": "VFH-WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%205.%20Sem..csv",
     "label": "WI",
     "faculty": "Informatik",
     "type": "csv",
     "id": "i_wi_5_ss21",
     "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%206.%20Sem..csv",
-    "label": "VFH-MI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%206.%20Sem..csv",
-    "label": "WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_wi_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
@@ -871,42 +736,6 @@
     "id": "i_alle_wpf_ss21",
     "semester": "WPF",
     "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
-    "label": "VFH-MI Wahlpflichtfaecher_1",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_mi_wahlpflichtfaecher_1_1_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/VFH-WI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
-    "label": "VFH-WI Wahlpflichtfaecher_1",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_wi_wahlpflichtfaecher_1_1_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%201.%20Sem..csv",
-    "label": "VFH-M.Sc. WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_m_wi_1_ss21",
-    "semester": 1,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%203.%20Sem..csv",
-    "label": "VFH-M.Sc. WI",
-    "faculty": "Informatik",
-    "type": "csv",
-    "id": "i_vfh_m_wi_3_ss21",
-    "semester": 3,
-    "degree": "Master"
   },
   {
     "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/M.Sc.%20Informatik%20(Alle%20Sem.+Schwerpunkte).csv",

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -1,81 +1,108 @@
 [
   {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html",
-    "label": "EIT(iP)-IT",
+    "skedPath": "e/semester/E-EIT-GS-Sem1.html",
+    "label": "EIT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_6_ss21",
-    "semester": 6,
+    "type": "graphical",
+    "id": "e_eit_gs_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-WEIT-Sem1.html",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT-GS-Sem2.html",
+    "label": "EIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_gs_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EITiP-GS-Sem2.html",
+    "label": "EITiP",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eitip_gs_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-WEIT-Sem2.html",
+    "label": "WEIT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-WEITiP-Sem2.html",
     "label": "WEITiP",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_weitip_2_ss21",
     "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT-GS-Sem1.html",
-    "label": "EIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_gs_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html",
-    "label": "EIT(iP)-AT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_at_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-GS-Sem3.html",
     "label": "EIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_gs_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html",
+    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html",
     "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_6_ss21",
-    "semester": 6,
+    "type": "graphical",
+    "id": "e_weit_ip_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html",
+    "label": "EIT(iP)-AT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_at_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem4.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html",
-    "label": "WEIT(iP)",
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_5_ss21",
-    "semester": 5,
+    "type": "graphical",
+    "id": "e_eit_ip_it_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-WEIT(iP)-Sem4.html",
     "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_weit_ip_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
@@ -84,268 +111,160 @@
     "skedPath": "e/semester/E-EIT(iP)-AT-Sem5.html",
     "label": "EIT(iP)-AT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_at_5_ss21",
     "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-WEIT-Sem1.html",
-    "label": "WEIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-IMES-VZ.html",
-    "label": "IMES Vollzeit",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_imes_vz_ss21",
-    "semester": "Sonstige",
-    "degree": "Master"
-  },
-  {
-    "skedPath": "e/semester/E-WEIT(iP)-Sem3.html",
-    "label": "WEIT(iP)",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_ip_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EITiP-GS-Sem2.html",
-    "label": "EITiP",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eitip_gs_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem4.html",
-    "label": "EIT(iP)-IT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-AT-Sem4.html",
-    "label": "EIT(iP)-AT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_at_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html",
-    "label": "EIT(iP)-IT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_ip_it_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "e/semester/E-EIT-GS-Sem2.html",
-    "label": "EIT",
-    "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_eit_gs_2_ss21",
-    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem5.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_5_ss21",
     "semester": 5,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-IMES-TZ.html",
-    "label": "IMES Teilzeit",
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem5.html",
+    "label": "EIT(iP)-IT",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_imes_tz_ss21",
-    "semester": "Sonstige",
-    "degree": "Master"
+    "type": "graphical",
+    "id": "e_eit_ip_it_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
   },
   {
-    "skedPath": "e/semester/E-WEIT-Sem2.html",
-    "label": "WEIT",
+    "skedPath": "e/semester/E-WEIT(iP)-Sem5.html",
+    "label": "WEIT(iP)",
     "faculty": "Elektrotechnik",
-    "graphical": true,
-    "id": "e_weit_2_ss21",
-    "semester": 2,
+    "type": "graphical",
+    "id": "e_weit_ip_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "e/semester/E-EIT(iP)-AT-Sem6.html",
+    "label": "EIT(iP)-AT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_at_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "e/semester/E-EIT(iP)-EE-Sem6.html",
     "label": "EIT(iP)-EE",
     "faculty": "Elektrotechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "e_eit_ip_ee_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/IVG2_SOSE2021.html",
-    "label": "IVG",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_ivg_2_ss21",
-    "semester": 2,
+    "skedPath": "e/semester/E-EIT(iP)-IT-Sem6.html",
+    "label": "EIT(iP)-IT",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_eit_ip_it_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/APIP5_SOSE2021.html",
-    "label": "APIP",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_apip_5_ss21",
-    "semester": 5,
+    "skedPath": "e/semester/E-WEIT(iP)-Sem6.html",
+    "label": "WEIT(iP)",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_weit_ip_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/MAG2_A1_SOSE2021.html",
-    "label": "MAG - Gruppe A1",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_a1_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
+    "skedPath": "e/semester/E-IMES-TZ.html",
+    "label": "IMES Teilzeit",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_imes_tz_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
   },
   {
-    "skedPath": "g/wp/APIP7_SOSE2021.html",
-    "label": "APIP",
+    "skedPath": "e/semester/E-IMES-VZ.html",
+    "label": "IMES Vollzeit",
+    "faculty": "Elektrotechnik",
+    "type": "graphical",
+    "id": "e_imes_vz_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
+  },
+  {
+    "skedPath": "g/wp/APP1_SOSE2021.html",
+    "label": "APP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_apip_7_ss21",
-    "semester": 7,
+    "type": "graphical",
+    "id": "g_app_1_ss21",
+    "semester": 1,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMP1_SOSE2021.html",
     "label": "BMP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_1_ss21",
     "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG2_B1_SOSE2021.html",
-    "label": "MAG - Gruppe B1",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_b1_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_KH_SOSE2021.html",
-    "label": "MAG - Schwerpunkt KH",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_kh_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/BMR3_M_SOSE2021.html",
-    "label": "BMR - Studienprofil M",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_bmr_m_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/APP1_SOSE2021.html",
-    "label": "APP",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_app_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/PM6_M_SOSE2021.html",
-    "label": "PM - Studienprofil M",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_pm_m_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/WPF_APB6_SOSE2021.html",
-    "label": "WPF APB 6. und höhere Sem.",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_wpf_apb6_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG2_A2_SOSE2021.html",
-    "label": "MAG - Gruppe A2",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_a_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_PH_SOSE2021.html",
-    "label": "MAG - Schwerpunkt PH",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_ph_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/WPF_MIG6_SOSE2021.html",
-    "label": "WPF MIG 6. und höhere Sem.",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_wpf_mig6_ss21",
-    "semester": "WPF",
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMR1_SOSE2021.html",
     "label": "BMR",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmr_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "g/wp/BMR3_B_SOSE2021.html",
-    "label": "BMR - Studienprofil B",
+    "skedPath": "g/wp/IVG2_SOSE2021.html",
+    "label": "IVG",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_bmr_b_3_ss21",
-    "semester": 3,
+    "type": "graphical",
+    "id": "g_ivg_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_A1_SOSE2021.html",
+    "label": "MAG - Gruppe A1",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_a1_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_A2_SOSE2021.html",
+    "label": "MAG - Gruppe A2",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_a_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG2_B1_SOSE2021.html",
+    "label": "MAG - Gruppe B1",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_b1_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/MAG2_B2_SOSE2021.html",
     "label": "MAG - Gruppe B2",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_mag_b_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
@@ -354,34 +273,16 @@
     "skedPath": "g/wp/APP3_SOSE2021.html",
     "label": "APP",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_app_3_ss21",
     "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/MAG4_KV_SOSE2021.html",
-    "label": "MAG - Schwerpunkt KV",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_mag_kv_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "g/wp/PM6_B_SOSE2021.html",
-    "label": "PM - Studienprofil B",
-    "faculty": "Gesundheitswesen",
-    "graphical": true,
-    "id": "g_pm_b_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "g/wp/BMP3_B_SOSE2021.html",
     "label": "BMP - Studienprofil B",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_b_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
@@ -390,70 +291,124 @@
     "skedPath": "g/wp/BMP3_M_SOSE2021.html",
     "label": "BMP - Studienprofil M",
     "faculty": "Gesundheitswesen",
-    "graphical": true,
+    "type": "graphical",
     "id": "g_bmp_m_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "h/wp/h_stdgrp_hul_4.html",
-    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_hul_4_ss21",
+    "skedPath": "g/wp/BMR3_B_SOSE2021.html",
+    "label": "BMR - Studienprofil B",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_bmr_b_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/BMR3_M_SOSE2021.html",
+    "label": "BMR - Studienprofil M",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_bmr_m_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_KH_SOSE2021.html",
+    "label": "MAG - Schwerpunkt KH",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_kh_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_KV_SOSE2021.html",
+    "label": "MAG - Schwerpunkt KV",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_kv_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/MAG4_PH_SOSE2021.html",
+    "label": "MAG - Schwerpunkt PH",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_mag_ph_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/APIP5_SOSE2021.html",
+    "label": "APIP",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_apip_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/PM6_B_SOSE2021.html",
+    "label": "PM - Studienprofil B",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_pm_b_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/PM6_M_SOSE2021.html",
+    "label": "PM - Studienprofil M",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_pm_m_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/APIP7_SOSE2021.html",
+    "label": "APIP",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_apip_7_ss21",
+    "semester": 7,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/WPF_APB6_SOSE2021.html",
+    "label": "WPF APB 6. und höhere Sem.",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_wpf_apb6_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "g/wp/WPF_MIG6_SOSE2021.html",
+    "label": "WPF MIG 6. und höhere Sem.",
+    "faculty": "Gesundheitswesen",
+    "type": "graphical",
+    "id": "g_wpf_mig6_ss21",
+    "semester": "WPF",
     "degree": "Bachelor"
   },
   {
     "skedPath": "h/wp/h_stdgrp_hul_2.html",
     "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_hul_2_ss21",
     "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_hul_6.html",
-    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_hul_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_5.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_6.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "h/wp/h_stdgrp_soa_4.html",
-    "label": "Soziale Arbeit",
-    "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
-    "id": "h_soa_4_ss21",
-    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "h/wp/h_stdgrp_soa_2.html",
     "label": "Soziale Arbeit",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_soa_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
@@ -462,89 +417,53 @@
     "skedPath": "h/wp/h_stdgrp_soa_3.html",
     "label": "Soziale Arbeit",
     "faculty": "Handel und Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "h_soa_3_ss21",
     "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-B-WR_2_2. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_wr_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-RPP_2_2. Sem..html",
-    "label": "Recht, Personalmangement und Psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_rpp_2_ss21",
-    "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-B-RPP_2_2. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rpp_2_ss21",
-    "semester": 2,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-B-RPP_1_1. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rpp_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-RPP_4_4. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_4_ss21",
+    "skedPath": "h/wp/h_stdgrp_hul_4.html",
+    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_hul_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RFS_3_3. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_3_ss21",
-    "semester": 3,
+    "skedPath": "h/wp/h_stdgrp_soa_4.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-B-RFS_2_2. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_b_rfs_2_ss21",
-    "semester": 2,
+    "skedPath": "h/wp/h_stdgrp_soa_5.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_5_ss21",
+    "semester": 5,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-WR_6_6. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wr_6_ss21",
+    "skedPath": "h/wp/h_stdgrp_hul_6.html",
+    "label": "Handel und Logistik - PO 2018 - Handel und Logistik",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_hul_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RPP_6_6. Sem..html",
-    "label": "Personalmanagement und -psychologie",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_6_ss21",
+    "skedPath": "h/wp/h_stdgrp_soa_6.html",
+    "label": "Soziale Arbeit",
+    "faculty": "Handel und Soziale Arbeit",
+    "type": "graphical",
+    "id": "h_soa_6_ss21",
     "semester": 6,
     "degree": "Bachelor"
   },
@@ -552,8 +471,17 @@
     "skedPath": "r/studentenset/R-B-RFS_1_1. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_b_rfs_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-B-RPP_1_1. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_b_rpp_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
@@ -561,133 +489,277 @@
     "skedPath": "r/studentenset/R-B-WR_1_1. Sem..html",
     "label": "Wirtschaftsrecht",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_b_wr_1_ss21",
     "semester": 1,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/Erstsemesterveranstaltungen_4_4. Sem..html",
-    "label": "Erstsemesterveranstaltungen",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_erstsemesterveranstaltungen_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-WPF-WF-Tutorien_4_4. Sem..html",
-    "label": "Wahlpflichtfächer SoSe 2021",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wpf_wf_tutorien_4_4_ss21",
-    "semester": "WPF",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-RFS_4_4. Sem..html",
+    "skedPath": "r/studentenset/R-B-RFS_2_2. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-Gremien und Sitzungen Aktuell.html",
-    "label": "Gremien und Sitzungen",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_gremien_und_sitzungen_aktuell_ss21",
-    "semester": "Sonstige",
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-FTC_2_2. Sem..html",
-    "label": "Finance, Tax and Company Law",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_ftc_2_ss21",
+    "type": "graphical",
+    "id": "r_b_rfs_2_ss21",
     "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-WR_3_3. Sem..html",
-    "label": "Wirtschaftsrecht",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_wr_3_ss21",
-    "semester": 3,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "r/studentenset/R-RFS_6_6. Sem..html",
-    "label": "Finanzmanagement und Steuern",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rfs_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "r/studentenset/R-M-ILB_2_2. Sem..html",
-    "label": "International Law and Business",
-    "faculty": "Recht",
-    "graphical": true,
-    "id": "r_m_ilb_2_ss21",
-    "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "r/studentenset/R-RPP_3_3. Sem..html",
+    "skedPath": "r/studentenset/R-B-RPP_2_2. Sem..html",
     "label": "Personalmanagement und -psychologie",
     "faculty": "Recht",
-    "graphical": true,
-    "id": "r_rpp_3_ss21",
-    "semester": 3,
+    "type": "graphical",
+    "id": "r_b_rpp_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-B-WR_2_2. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_b_wr_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "r/studentenset/R-Exkursionen_3_3. Sem..html",
     "label": "Exkursionen (derzeit finden keine Exkursionen statt)",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_exkursionen_3_ss21",
     "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_3_3. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_3_3. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WR_3_3. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wr_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/Erstsemesterveranstaltungen_4_4. Sem..html",
+    "label": "Erstsemesterveranstaltungen",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_erstsemesterveranstaltungen_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_4_4. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_4_4. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_4_ss21",
+    "semester": 4,
     "degree": "Bachelor"
   },
   {
     "skedPath": "r/studentenset/R-WR_4_4. Sem..html",
     "label": "Wirtschaftsrecht",
     "faculty": "Recht",
-    "graphical": true,
+    "type": "graphical",
     "id": "r_wr_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RFS_6_6. Sem..html",
+    "label": "Finanzmanagement und Steuern",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rfs_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-RPP_6_6. Sem..html",
+    "label": "Personalmanagement und -psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_rpp_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WR_6_6. Sem..html",
+    "label": "Wirtschaftsrecht",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wr_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-Gremien und Sitzungen Aktuell.html",
+    "label": "Gremien und Sitzungen",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_gremien_und_sitzungen_aktuell_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-WPF-WF-Tutorien_4_4. Sem..html",
+    "label": "Wahlpflichtfächer SoSe 2021",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_wpf_wf_tutorien_4_4_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-FTC_2_2. Sem..html",
+    "label": "Finance, Tax and Company Law",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_ftc_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-ILB_2_2. Sem..html",
+    "label": "International Law and Business",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_ilb_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "r/studentenset/R-M-RPP_2_2. Sem..html",
+    "label": "Recht, Personalmangement und Psychologie",
+    "faculty": "Recht",
+    "type": "graphical",
+    "id": "r_m_rpp_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_1_1. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Berufsanerkennungsjahr_1_1. Sem.html",
+    "label": "Berufsanerkennungsjahr SoSe 21",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_berufsanerkennungsjahr_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/S-Fakultaetstermine_1_1. Sem.html",
+    "label": "Fakultätstermine SS 2021 - Gremienzeiten",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_fakultaetstermine_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Weiterbindlung Erlebnispaedagogok_1_1. Sem.html",
+    "label": "Weiterbindlung Erlebnispädagogok",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_weiterbindlung_erlebnispaedagogok_1_ss21",
+    "semester": 1,
     "degree": "Bachelor"
   },
   {
     "skedPath": "s/wp/Bachelor Soziale Arbeit_2_2. Sem.html",
     "label": "Bachelor",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
   },
   {
-    "skedPath": "s/wp/MA MSM_4_4. Sem.html",
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_3_3. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_4_4. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_5_5. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/Bachelor Soziale Arbeit_6_6. Sem.html",
+    "label": "Bachelor",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "s/wp/MA MSM_1_1. Sem.html",
     "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_4_ss21",
-    "semester": 4,
+    "type": "graphical",
+    "id": "s_ma_msm_1_ss21",
+    "semester": 1,
     "degree": "Master"
   },
   {
     "skedPath": "s/wp/MA 2020 PSA_1_1. Sem.html",
     "label": "Master Präventive - Schwerpunkt 1",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_2020_psa_1_ss21",
     "semester": 1,
     "degree": "Master"
@@ -696,142 +768,25 @@
     "skedPath": "s/wp/MA PSA_1_1. Sem. - Schwerpunkt 1.html",
     "label": "Master Präventive - Schwerpunkt 2",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_1_ss21",
     "semester": 1,
     "degree": "Master"
   },
   {
-    "skedPath": "s/wp/MA PSA_3. Semester_Schwerpunkt 2.html",
-    "label": "Master Präventive - Schwerpunkt 2",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_psa_schwerpunkt_2_3_ss21",
-    "semester": 3,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Berufsanerkennungsjahr_1_1. Sem.html",
-    "label": "Berufsanerkennungsjahr SoSe 21",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_berufsanerkennungsjahr_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/MA MSM_1_1. Sem.html",
-    "label": "Fernstudiengang Master Sozialmanagement",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_1_ss21",
-    "semester": 1,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Weiterbindlung Erlebnispaedagogok_1_1. Sem.html",
-    "label": "Weiterbindlung Erlebnispädagogok",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_weiterbindlung_erlebnispaedagogok_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 2.html",
-    "label": "Master Präventive - Schwerpunkt 2",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_2_4_ss21",
-    "semester": 4,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_5_5. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_5_ss21",
-    "semester": 5,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_3_3. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_3_ss21",
-    "semester": 3,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 1.html",
-    "label": "Master Präventive - Schwerpunkt 1",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_1_4_ss21",
-    "semester": 4,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_4_4. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_4_ss21",
-    "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
     "skedPath": "s/wp/MA MSM_2_2. Sem.html",
     "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_msm_2_ss21",
     "semester": 2,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/S-Fakultaetstermine_1_1. Sem.html",
-    "label": "Fakultätstermine SS 2021 - Gremienzeiten",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_fakultaetstermine_1_ss21",
-    "semester": 1,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/MA MSM_3_3. Sem.html",
-    "label": "Fernstudiengang Master Sozialmanagement",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_ma_msm_3_ss21",
-    "semester": 3,
-    "degree": "Master"
-  },
-  {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_6_6. Sem.html",
-    "label": "Bachelor",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "s/wp/Master PSA_3. Sem._Schwerpunkt 1.html",
-    "label": "Master Präventive - Schwerpunkt 1",
-    "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_master_psa_schwerpunkt_1_3_ss21",
-    "semester": 3,
     "degree": "Master"
   },
   {
     "skedPath": "s/wp/MA PSA_2_2. Sem. - Schwerpunkt 2_Kopie.html",
     "label": "Master Präventive - Schwerpunkt 1",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_kopie_2_ss21",
     "semester": 2,
     "degree": "Master"
@@ -840,97 +795,205 @@
     "skedPath": "s/wp/MA PSA_2_Schwerpunkt 1.html",
     "label": "Master Präventive - Schwerpunkt 2",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
+    "type": "graphical",
     "id": "s_ma_psa_schwerpunkt_1_2_ss21",
     "semester": 2,
     "degree": "Master"
   },
   {
-    "skedPath": "s/wp/Bachelor Soziale Arbeit_1_1. Sem.html",
-    "label": "Bachelor",
+    "skedPath": "s/wp/MA MSM_3_3. Sem.html",
+    "label": "Fernstudiengang Master Sozialmanagement",
     "faculty": "Soziale Arbeit",
-    "graphical": true,
-    "id": "s_1_ss21",
+    "type": "graphical",
+    "id": "s_ma_msm_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_3. Sem._Schwerpunkt 1.html",
+    "label": "Master Präventive - Schwerpunkt 1",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_1_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/MA PSA_3. Semester_Schwerpunkt 2.html",
+    "label": "Master Präventive - Schwerpunkt 2",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_ma_psa_schwerpunkt_2_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/MA MSM_4_4. Sem.html",
+    "label": "Fernstudiengang Master Sozialmanagement",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_ma_msm_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 1.html",
+    "label": "Master Präventive - Schwerpunkt 1",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_1_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "s/wp/Master PSA_4. Sem._Schwerpunkt 2.html",
+    "label": "Master Präventive - Schwerpunkt 2",
+    "faculty": "Soziale Arbeit",
+    "type": "graphical",
+    "id": "s_master_psa_schwerpunkt_2_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/BEE_2020_SoSe_1_1. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_2020_1_ss21",
     "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/EGT_2020_SoSe_1_1. Sem..html",
+    "label": "EGT / EGTiP",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_2020_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/ge/GE_1_1. Sem..html",
+    "label": "Green Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_ge_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/sce/SCE_1_1. Sem..html",
+    "label": "Smart City Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_sce_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_1_1. Sem..html",
+    "label": "WING E",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/WING Umwelt_2020_SoSe_1_1. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_2020_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_2_2. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/dt/Digital Technologies (DT Energie)_2_2. Sem..html",
+    "label": "DT Energie",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_digital_technologies_dt_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_2_2. Sem..html",
+    "label": "EGT / EGTiP",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/ge/Green Engineering_2_2. Sem..html",
+    "label": "Green Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_green_engineering_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/sce/Smart City Engineering_2_2. Sem..html",
+    "label": "Smart City Engineering",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_smart_city_engineering_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_2_2. Sem..html",
+    "label": "WING E",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_2_2. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_u_2_ss21",
+    "semester": 2,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_4_4. Sem..html",
     "label": "BEE",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_bee_4_ss21",
     "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_6_6. Sem..html",
-    "label": "BEE",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_bee_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem..html",
-    "label": "EGT / EGTiP ÖIV",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. TGA.html",
-    "label": "EGT / EGTiP PO13",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_tga_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_4_4. Sem..html",
     "label": "EGT / EGTiP",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_egt_egtip_4_ss21",
     "semester": 4,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. OeIV.html",
-    "label": "EGT / EGTiP TGA",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_egt_egtip_oeiv_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_6_6. Sem..html",
-    "label": "WING U",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_wing_u_6_ss21",
-    "semester": 6,
-    "degree": "Bachelor"
-  },
-  {
-    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_6_6. Semester.html",
-    "label": "WING E (PO 2018)",
-    "faculty": "Versorgungstechnik",
-    "graphical": true,
-    "id": "v_wing_e_6_ss21",
-    "semester": 6,
     "degree": "Bachelor"
   },
   {
     "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_4_4. Sem..html",
     "label": "WING E",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_wing_e_4_ss21",
     "semester": 4,
     "degree": "Bachelor"
@@ -939,9 +1002,63 @@
     "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_4_4. Sem..html",
     "label": "WING U",
     "faculty": "Versorgungstechnik",
-    "graphical": true,
+    "type": "graphical",
     "id": "v_wing_u_4_ss21",
     "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/bee/Bio- und Umwelttechnik (BEE )_6_6. Sem..html",
+    "label": "BEE",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_bee_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. TGA.html",
+    "label": "EGT / EGTiP PO13",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_tga_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem. OeIV.html",
+    "label": "EGT / EGTiP TGA",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_oeiv_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/egt/Energie- und Gebaeudetechnik (EGT - EGTiP)_6_6. Sem..html",
+    "label": "EGT / EGTiP ÖIV",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_egt_egtip_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Energie (WING E)_6_6. Semester.html",
+    "label": "WING E (PO 2018)",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_e_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "v/stundenplan/wing/Wirtschaftsingenieur Umwelt (WING U)_6_6. Sem..html",
+    "label": "WING U",
+    "faculty": "Versorgungstechnik",
+    "type": "graphical",
+    "id": "v_wing_u_6_ss21",
+    "semester": 6,
     "degree": "Bachelor"
   }
 ]

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -855,6 +855,294 @@
     "degree": "Master"
   },
   {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_2.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lom_2.html",
+    "label": "Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lom_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lop_2.html",
+    "label": "Logistikmanagement im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lop_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_md_2.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_md_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mk_2.html",
+    "label": "Medienkommunikation",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mk_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mm_2.html",
+    "label": "Medienmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mpm_2.html",
+    "label": "Mobilität und Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mpm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_spm_2.html",
+    "label": "Sportmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_spm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_srm_2.html",
+    "label": "Stadt- und Regionalmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_srm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tm_2.html",
+    "label": "Tourismusmangement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tm_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wmv_2.html",
+    "label": "Wirtschaftsingenieurwesen Mobilität und Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wmv_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_4.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_md_4.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_md_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mk_4.html",
+    "label": "Medienkommunikation",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mk_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mm_4.html",
+    "label": "Medienmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_pvm_4.html",
+    "label": "Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_pvm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_spm_4.html",
+    "label": "Sportmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_spm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_srm_4.html",
+    "label": "Stadt- und Regionalmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_srm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tm_4.html",
+    "label": "Tourismusmangement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tlm_4.html",
+    "label": "Transport- und Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tlm_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wiv_4.html",
+    "label": "Wirtschaftsingenieurwesen Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wiv_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lip_4.html",
+    "label": "Logistik im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lip_4_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lim_6.html",
+    "label": "Logistik und Informationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lim_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_pvm_6.html",
+    "label": "Personenverkehrsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_pvm_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_tlm_6.html",
+    "label": "Transport- und Logistikmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_tlm_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_wiv_6.html",
+    "label": "Wirtschaftsingenieurwesen Verkehr",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_wiv_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_lip_8.html",
+    "label": "Logistik im Praxisverbund",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_lip_8_ss21",
+    "semester": 8,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_mvl_1.html",
+    "label": "Verkehr und Logistik",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_mvl_1_ss21",
+    "semester": 1,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_fdu_2.html",
+    "label": "Führung in Dienstleistungsunternehmen",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_fdu_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_km_2.html",
+    "label": "Kommunikationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_km_2_ss21",
+    "semester": 2,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_fdu_4.html",
+    "label": "Führung in Dienstleistungsunternehmen",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_fdu_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_m_km_4.html",
+    "label": "Kommunikationsmanagement",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_m_km_4_ss21",
+    "semester": 4,
+    "degree": "Master"
+  },
+  {
     "skedPath": "v/stundenplan/bee/BEE_2020_SoSe_1_1. Sem..html",
     "label": "BEE",
     "faculty": "Versorgungstechnik",

--- a/web/assets/timetables.json
+++ b/web/assets/timetables.json
@@ -468,6 +468,456 @@
     "degree": "Bachelor"
   },
   {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%201.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Informatik%201.%20Sem.csv",
+    "label": "Informatik",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_informatik_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%201.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%201.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%201.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_1_ss21",
+    "semester": 1,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%202.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%202.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%202.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%202.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%202.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%202.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%202.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%203.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%203.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%203.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%203.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%203.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO13).csv",
+    "label": "SYE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po13_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%203.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%203.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%203.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%203.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_3_ss21",
+    "semester": 3,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%204.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20Digital%20Technologies%204.%20Sem..csv",
+    "label": "Digital Technologies",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_digital_technologies_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO13).csv",
+    "label": "IE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po13_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%204.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/IT-Management_4_4.%20Sem..csv",
+    "label": "IT-Management_4",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_it_management_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%204.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%204.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO13).csv",
+    "label": "SYE (PO13)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po13_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%204.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI_4_4.%20Sem..csv",
+    "label": "WI_4",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_4_ss21",
+    "semester": 4,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20CE%205.%20Sem.%20(PO18).csv",
+    "label": "CE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ce_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20IE%205.%20Sem.%20(PO18).csv",
+    "label": "IE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_ie_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20MEI%205.%20Sem.%20(PO18).csv",
+    "label": "MEI (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_mei_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SOE%205.%20Sem.%20(PO18).csv",
+    "label": "SOE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_soe_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20SYE%205.%20Sem.%20(PO18).csv",
+    "label": "SYE (PO18)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sye_po18_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%205.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-WI%205.%20Sem..csv",
+    "label": "VFH-WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%205.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_5_ss21",
+    "semester": 5,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%206.%20Sem..csv",
+    "label": "VFH-MI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-B.Sc.%20WI%206.%20Sem..csv",
+    "label": "WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_wi_6_ss21",
+    "semester": 6,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Career%20Service.csv",
+    "label": "Career Service",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_career_service_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Sprachenzentrum.csv",
+    "label": "Sprachenzentrum",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_sprachenzentrum_ss21",
+    "semester": "Sonstige",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/Alle%20WPF.csv",
+    "label": "Alle WPF",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_alle_wpf_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-MI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
+    "label": "VFH-MI Wahlpflichtfaecher_1",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_mi_wahlpflichtfaecher_1_1_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/VFH-WI%20Wahlpflichtfaecher_1_1.%20Sem..csv",
+    "label": "VFH-WI Wahlpflichtfaecher_1",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_wi_wahlpflichtfaecher_1_1_ss21",
+    "semester": "WPF",
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%201.%20Sem..csv",
+    "label": "VFH-M.Sc. WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_m_wi_1_ss21",
+    "semester": 1,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/I-VFH-M.Sc.%20WI%203.%20Sem..csv",
+    "label": "VFH-M.Sc. WI",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_vfh_m_wi_3_ss21",
+    "semester": 3,
+    "degree": "Master"
+  },
+  {
+    "skedPath": "i/Alle%20Daten%20im%20CSV-Format/Semester/M.Sc.%20Informatik%20(Alle%20Sem.+Schwerpunkte).csv",
+    "label": "M.Sc. Informatik (Alle Sem.+Schwerpunkte)",
+    "faculty": "Informatik",
+    "type": "csv",
+    "id": "i_m_informatik_alle_schwerpunkte_ss21",
+    "semester": "Sonstige",
+    "degree": "Master"
+  },
+  {
     "skedPath": "r/studentenset/R-B-RFS_1_1. Sem..html",
     "label": "Finanzmanagement und Steuern",
     "faculty": "Recht",
@@ -887,6 +1337,15 @@
     "faculty": "Verkehr-Sport-Tourismus-Medien",
     "type": "graphical",
     "id": "k_md_2_ss21",
+    "semester": 2,
+    "degree": "Bachelor"
+  },
+  {
+    "skedPath": "k/prod/vorlesungsplaene/wp/ss/stjg_mdma_2.html",
+    "label": "Mediendesign",
+    "faculty": "Verkehr-Sport-Tourismus-Medien",
+    "type": "graphical",
+    "id": "k_mdma_2_ss21",
     "semester": 2,
     "degree": "Bachelor"
   },


### PR DESCRIPTION
Neue Informatik-Pläne mit CSV!

Änderungen:
* `csv-string` library für's CSV-Parsen hinzugefügt
* Den `graphical`-Parameter in der `timetables.json` umbenannt in `type`, akzeptiert entweder `list`, `graphical` oder `csv`.
* Die bestehenden Timetables auf das neue Format konvertiert mittels https://github.com/SplusEins/sked_parser/commit/7a0d5a2db2e04220ac9569ee648f9a341d55fd8e. Dabei wurden auch direkt neue Timetables der Versorgungstechnik hinzugefügt. Der `timetables.json`-File ist jetzt zudem sortiert, sodass Änderungen in Zukunft leichter vergleichbar sind. 
* Docs aktualisiert auf neues Format.