### PR TITLE
Fix bus line names after HAFAS updates

### DIFF
--- a/server/controllers/bus.ts
+++ b/server/controllers/bus.ts
@@ -49,7 +49,7 @@ router.get('/', async (req, res, next) => {
         .map(legs => legs[0])
         .map(leg => ({
           date: leg.departure,
-          line: leg.line.name.replace('Bus ', '') // remove Bus string at start
+          line: leg.line.name.replace('Bus', '').replace('AST', '').trim() // remove Bus string at start
         }))
         .sort((a, b) => Date.parse(a) - Date.parse(b));
 


### PR DESCRIPTION
Seit dem hafas client update in #457 gibt die API statt der Liniennummer den vollen Namen der Linie zurück, z.B. "Bus 740". Das hatte ich in dem PR berücksichtigt, aber aus unerklärlichen Gründen gibt der hafas client auch manchmal "AST 798" zurück, siehe Bild. AST bedeutet Anrufsammeltaxi. Macht keinen Sinn, da es ne Buslinie ist, aber ich entferne das jetzt trotzdem 🤷. 

![image](https://user-images.githubusercontent.com/12055376/109419578-73ebf700-79ce-11eb-952c-5e74133f5347.png)