### PR TITLE
API: Improve news fetching/parsing and add RSS support

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -119,7 +119,7 @@ Die Endpunkte zum Abfragen der News-Daten befinden sich in der Datei `controller
 
 **Parameter:**
 
-- newstypes: Komma getrennte Liste von News-Quellen. Unterstützte Quellen sind nahezu alle Fakultäten (`r`, `v`, `m`, `b`, `k`, `h`, `f`, `g`, `w`, `e`, `s`). Nur Informatik wird nicht unterstützt, da ein eigenes Format für die News genutzt wird. Weiterhin unterstützt sind alle Ostfalia-Standorte (`wob`, `wf`, `sud`, `sz`) sowie die Ostfalia-globalen News `campus` und die Campus38-News mittels `campus38`.
+- newstypes: Komma getrennte Liste von News-Quellen. Unterstützte Quellen sind die meisten Fakultäten: `r`, `b`, `k`, `h`, `f`, `g`, `w`, `e`, `s`. Weiterhin unterstützt sind alle Ostfalia-Standorte (`wob`, `wf`, `sud`, `sz`) sowie die Ostfalia-globalen News `campus` und die Campus38-News mittels `campus38`.
 - limit: Optional, limitiert die zurückgegebenen News auf diese Anzahl. Maximal zurückgegeben werden die 100 letzten News.
 
 **Rückgabe:**

--- a/docs/server.md
+++ b/docs/server.md
@@ -115,19 +115,23 @@ Liefert einen Plan der 5 nächsten Abfahrten des Nahverkehrs in Wolfenbüttel zw
 
 Die Endpunkte zum Abfragen der News-Daten befinden sich in der Datei `controller/news.ts`.
 
-### GET `/news/campus`
+### GET `/news/:newstypes?limit=NUMBER`
 
-**Parameter:** keine
+**Parameter:**
 
-**Rückgabe:**
-Liefert ein NewsElement-Array (siehe `model/SplusEinsModel.ts`), welches allgemeine Neuigkeiten über die Ostfalia enthält. Die Daten werden von der Ostfalia Website und von Campus38 bezogen.
-
-### GET `/news/faculty`
-
-**Parameter:** keine
+- newstypes: Komma getrennte Liste von News-Quellen. Unterstützte Quellen sind nahezu alle Fakultäten (`r`, `v`, `m`, `b`, `k`, `h`, `f`, `g`, `w`, `e`, `s`). Nur Informatik wird nicht unterstützt, da ein eigenes Format für die News genutzt wird. Weiterhin unterstützt sind alle Ostfalia-Standorte (`wob`, `wf`, `sud`, `sz`) sowie die Ostfalia-globalen News `campus` und die Campus38-News mittels `campus38`.
+- limit: Optional, limitiert die zurückgegebenen News auf diese Anzahl. Maximal zurückgegeben werden die 100 letzten News.
 
 **Rückgabe:**
-Liefert ein NewsElement-Array (siehe `model/SplusEinsModel.ts`), welches Neuigkeiten der Fakultäten Informatik, Recht und E-Technik sowie den Standorten Wolfenbüttel, Wolfsburg und Suderburg enthält. Die Daten stammen von den jeweiligen Ostfalia-Webseiten.
+Liefert ein NewsElement-Array (siehe `model/SplusEinsModel.ts`) mit den ausgewählten News zurück. Die Beschreibungen werden auf 130 Zeichen gekürzt und die News nach Datum sortiert. Einzige Ausnahme bei der Sortierung sind die `campus38`-News. Diese werden etwas geringer gewichtet, da diese deutlich häufiger erscheinen als die sonstigen News.
+
+### GET `/news/:newstypes.rss?limit=NUMBER`
+
+**Parameter:**
+Erwartet dieselben Parameter wie die normale News-API.
+
+**Rückgabe:**
+Gibt dieselben Daten als RSS-Feed zurück.
 
 ## Parser
 

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -1,64 +1,29 @@
 import * as express from 'express';
 
-import { getCampusNews, getFacultyNews } from '../lib/NewsApi'
+import getNews from '../lib/NewsApi'
 
 const CACHE_SECONDS = parseInt(process.env.NEWS_CACHE_SECONDS || '1800');
 const router = express.Router();
 
-const flatten = <T>(arr: T[][]) => [].concat(...arr) as T[];
-
 /**
  * Accept CORS preflight requests.
  */
-router.options('/campus');
 router.options('/:faculties');
-
-/**
- * Get campus news
- * @returns NewsElement[]
- */
-router.get('/campus', async (req, res, next) => {
-  try {
-    const campusNews = await getCampusNews();
-    res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-    res.json(campusNews);
-  } catch (error) {
-    next(error);
-  }
-});
 
 /**
  * Get ostfalia faculty news
  * @returns NewsElement[]
  */
-router.get('/:faculties', async (req, res, next) => {
-  let faculties = <string[]>req.params.faculties.split(',');
-  if (faculties.length == 1 && faculties[0] == "faculty"){
-    // for backward compatibility only, if request was /api/news/faculty
-    faculties = ['i', 'r', 'e', 'wf', 'wob', 'sud'];
-  }
+router.get('/:faculties', async (req, res) => {
+  const faculties = <string[]>req.params.faculties.split(',');
   
   try {
-    let facultyNews = await Promise.all(
-      faculties.map(async (faculty) => {
-        try {
-          return await getFacultyNews(faculty);
-        } catch (e) {
-          console.log(`Error while loading faculty news for "${faculty}": ${e.message}`)
-          return [];
-        }
-      })
-    ).then(flatten)
-    const sortByDate = (a1, a2) => {
-      const date1 = new Date(a1.date).getTime();
-      const date2 = new Date(a2.date).getTime();
-      return date2 - date1;
-    };
-    facultyNews = facultyNews.sort(sortByDate);
+    const facultyNews = await getNews(faculties);
     res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
     res.json(facultyNews);
   } catch (error) {
-    next(error);
+    res.status(404).send(error.message);
+    console.log(`Error while fetching news ${error.message}`)
   }
 });
 

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -32,7 +32,7 @@ router.get('/:newstypes\.:ext?', async (req, res) => {
     return res.status(404).send(error.message);
   }
   res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-  if (req.params.ext != 'rss') {
+  if (req.params.ext !== 'rss') {
     // Normal request, send news as JSON
     return res.json(news);
   } else {

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -1,14 +1,51 @@
 import * as express from 'express';
-
+import * as rss from 'rss';
+import { } from 'rss';
 import getNews from '../lib/NewsApi'
+import { NewsElement } from '~/model/SplusEinsModel';
+import * as crypto from 'crypto';
 
 const CACHE_SECONDS = parseInt(process.env.NEWS_CACHE_SECONDS || '1800');
 const router = express.Router();
 
+const MAX_NEWS_ITEMS = 100;
+
 /**
  * Accept CORS preflight requests.
  */
+router.options('/:faculties.rss');
 router.options('/:faculties');
+
+router.get('/:faculties.rss', async (req, res, next) => {
+  const faculties = <string[]>req.params.faculties.split(',');
+  let limit = parseInt(req.query.limit) || MAX_NEWS_ITEMS;
+  if (limit > MAX_NEWS_ITEMS) limit = MAX_NEWS_ITEMS;
+
+  try {
+    const news = await getNews(faculties, limit);
+    const feed = new rss({ title: '', feed_url: '', site_url: '' });
+    const generateUid = (article: NewsElement) => (
+      crypto.createHash('sha1').update(article.title + article.date).digest('base64').slice(0, 7)
+    )
+    news.map(newsEl => {
+      return {
+        title: newsEl.title,
+        description: newsEl.text,
+        url: newsEl.link,
+        categories: [newsEl.source],
+        date: newsEl.date,
+        guid: generateUid(newsEl)
+      };
+    }).forEach(feedItem => feed.item(feedItem));
+
+    res.set('Content-Type', 'application/rss+xml');
+    //res.set('Content-Disposition', 'attachment;filename="spluseins.ics"');
+    res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
+    res.send(feed.xml());
+  } catch (error) {
+    next(error);
+  }
+});
 
 /**
  * Get ostfalia faculty news
@@ -16,11 +53,13 @@ router.options('/:faculties');
  */
 router.get('/:faculties', async (req, res) => {
   const faculties = <string[]>req.params.faculties.split(',');
-  
+  let limit = parseInt(req.query.limit) || MAX_NEWS_ITEMS;
+  if (limit > MAX_NEWS_ITEMS) limit = MAX_NEWS_ITEMS;
+
   try {
-    const facultyNews = await getNews(faculties);
+    const news = await getNews(faculties, limit);
     res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-    res.json(facultyNews);
+    res.json(news);
   } catch (error) {
     res.status(404).send(error.message);
     console.log(`Error while fetching news ${error.message}`)

--- a/server/controllers/news.ts
+++ b/server/controllers/news.ts
@@ -1,5 +1,6 @@
+/* eslint-disable no-useless-escape */
 import * as express from 'express';
-import * as rss from 'rss';
+import * as RSS from 'rss';
 import { } from 'rss';
 import getNews from '../lib/NewsApi'
 import { NewsElement } from '~/model/SplusEinsModel';
@@ -13,56 +14,47 @@ const MAX_NEWS_ITEMS = 100;
 /**
  * Accept CORS preflight requests.
  */
-router.options('/:faculties.rss');
-router.options('/:faculties');
-
-router.get('/:faculties.rss', async (req, res, next) => {
-  const faculties = <string[]>req.params.faculties.split(',');
-  let limit = parseInt(req.query.limit) || MAX_NEWS_ITEMS;
-  if (limit > MAX_NEWS_ITEMS) limit = MAX_NEWS_ITEMS;
-
-  try {
-    const news = await getNews(faculties, limit);
-    const feed = new rss({ title: '', feed_url: '', site_url: '' });
-    const generateUid = (article: NewsElement) => (
-      crypto.createHash('sha1').update(article.title + article.date).digest('base64').slice(0, 7)
-    )
-    news.map(newsEl => {
-      return {
-        title: newsEl.title,
-        description: newsEl.text,
-        url: newsEl.link,
-        categories: [newsEl.source],
-        date: newsEl.date,
-        guid: generateUid(newsEl)
-      };
-    }).forEach(feedItem => feed.item(feedItem));
-
-    res.set('Content-Type', 'application/rss+xml');
-    //res.set('Content-Disposition', 'attachment;filename="spluseins.ics"');
-    res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-    res.send(feed.xml());
-  } catch (error) {
-    next(error);
-  }
-});
+router.options('/:newstypes\.:ext?');
 
 /**
  * Get ostfalia faculty news
  * @returns NewsElement[]
  */
-router.get('/:faculties', async (req, res) => {
-  const faculties = <string[]>req.params.faculties.split(',');
-  let limit = parseInt(req.query.limit) || MAX_NEWS_ITEMS;
+router.get('/:newstypes\.:ext?', async (req, res) => {
+  const newstypes = <string[]>req.params.newstypes.split(',');
+  let limit = parseInt(req.query.limit as string) || MAX_NEWS_ITEMS;
   if (limit > MAX_NEWS_ITEMS) limit = MAX_NEWS_ITEMS;
-
+  let news: NewsElement[];
   try {
-    const news = await getNews(faculties, limit);
-    res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
-    res.json(news);
+    news = await getNews(newstypes, limit);
   } catch (error) {
-    res.status(404).send(error.message);
-    console.log(`Error while fetching news ${error.message}`)
+    console.log(`Error while fetching news: ${error.message}`)
+    return res.status(404).send(error.message);
+  }
+  res.set('Cache-Control', `public, max-age=${CACHE_SECONDS}`);
+  if (req.params.ext != 'rss') {
+    // Normal request, send news as JSON
+    return res.json(news);
+  } else {
+    // Request ends with .rss, create and send RSS feed
+    const news = await getNews(newstypes, limit);
+    const hostUrl = req.protocol + '://' + req.get('host');
+    const feed = new RSS({
+      title: `SplusEins news feed (for ${req.params.newstypes})`,
+      feed_url: hostUrl + req.originalUrl,
+      site_url: hostUrl
+    });
+    // Map news items to rss feed items
+    news.map((newsEl: NewsElement) => ({
+      title: newsEl.title,
+      description: newsEl.text,
+      url: newsEl.link,
+      categories: [newsEl.source],
+      date: newsEl.date,
+      guid: crypto.createHash('sha1').update(newsEl.title + newsEl.date).digest('base64').replace(/\W/g, '').slice(0, 8)
+    })).forEach(feedItem => feed.item(feedItem));
+    res.set('Content-Type', 'application/rss+xml');
+    return res.send(feed.xml());
   }
 });
 

--- a/server/lib/NewsApi.ts
+++ b/server/lib/NewsApi.ts
@@ -37,7 +37,7 @@ async function ostfaliaNewsRequest (newsSelector: string): Promise<NewsElement[]
     newsSelector = 'campus/' + newsSelector;
   }
   const query = new URLSearchParams();
-  query.append('itemsPerPage', '20');
+  query.append('itemsPerPage', '30');
   // Syntax of collectorParam very similar to https://documentation.opencms.org/opencms-documentation/more-opencms-features/solr-search-integration
   // so that param will probably be forwarded to Apache SOLR
   query.append('collectorParam',
@@ -89,12 +89,14 @@ async function campus38NewsRequest (): Promise<NewsElement[]> {
  * Helper function for cleaning news articles
  * @param news news to parse
  * @param limit Limit the news elements to this number
- * @returns filtered and sorted news articles with truncated descriptions
+ * @returns filtered (no duplicates or items with future date) and sorted news articles with truncated descriptions
  */
 function truncateAndSortNews (news: NewsElement[], limit: number): NewsElement[] {
   // don't show articles that are more than x days in the future,
   // can happen in some rare cases where news items = calendar items (like faculty S)
   news = news.filter(article => (moment(article.date).diff(moment(), 'days') < 3))
+  // Filter any duplicate entries (based on title+desc)
+  news = news.filter((v, i, a) => a.findIndex(t => (t.title === v.title && t.text === v.text)) === i)
 
   // Truncate article descriptions
   news = news.map(article => {
@@ -134,7 +136,7 @@ function truncateAndSortNews (news: NewsElement[], limit: number): NewsElement[]
  * @returns NewsElement[] Sorted news for the specified `newsSelectors`
  */
 export default async function getNews (newsSelectors: string[], limit: number): Promise<NewsElement[]> {
-  const facultySelectors = ['r', 'v', 'm', 'b', 'k', 'h', 'f', 'g', 'w', 'e', 's']; // all allowed faculties
+  const facultySelectors = ['r', 'b', 'k', 'h', 'f', 'g', 'w', 'e', 's']; // all allowed faculties
   const campusSelectors = ['wob', 'wf', 'sud', 'sz']; // all allowed campuses/standorte
   const otherSelectors = ['campus', 'campus38']; // currently only ostfalia global news and Campus 38 news.
   const allowedSelectors = facultySelectors.concat(campusSelectors, otherSelectors);

--- a/server/lib/NewsApi.ts
+++ b/server/lib/NewsApi.ts
@@ -90,7 +90,7 @@ async function campus38NewsRequest(): Promise<NewsElement[]> {
  * @param news news to parse
  * @returns filtered and sorted news articles with truncated descriptions
  */
-function truncateAndSortNews(news: NewsElement[]): NewsElement[] {
+function truncateAndSortNews(news: NewsElement[], limit: number): NewsElement[] {
   // don't show articles that are more than x days in the future, 
   // can happen in some rare cases where news items = calendar items (like faculty S)
   news = news.filter(article => (moment(article.date).diff(moment(), 'days') < 3))
@@ -121,7 +121,10 @@ function truncateAndSortNews(news: NewsElement[]): NewsElement[] {
     const boost = article.source == 'campus38' ? 0.35 : 1.0;
     return age / boost;
   };
-  return news.sort((a1, a2) => scoreArticle(a1) - scoreArticle(a2));
+  news = news.sort((a1, a2) => scoreArticle(a1) - scoreArticle(a2));
+  // Cut array after limit (yes this is legit javascript: https://stackoverflow.com/a/31560542/4026792)
+  news.length = limit;
+  return news;
 }
 
 /**
@@ -130,7 +133,7 @@ function truncateAndSortNews(news: NewsElement[]): NewsElement[] {
  * @param newsSelectors faculty
  * @returns NewsElement[]
  */
-export default async function getNews(newsSelectors: string[]): Promise<NewsElement[]> {
+export default async function getNews(newsSelectors: string[], limit: number): Promise<NewsElement[]> {
   const facultySelectors = ['r', 'v', 'm', 'b', 'k', 'h', 'f', 'g', 'w', 'e', 's']; // all allowed faculties
   const campusSelectors = ['wob', 'wf', 'sud', 'sz']; // all allowed campuses/standorte
   const otherSelectors = ['campus', 'campus38']; // currently only ostfalia global news and Campus 38 news.
@@ -155,5 +158,5 @@ export default async function getNews(newsSelectors: string[]): Promise<NewsElem
       }
     })
   ).then(flatten);
-  return truncateAndSortNews(facultyNews);
+  return truncateAndSortNews(facultyNews, limit);
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,7 +20,8 @@
         "ical-generator": "^1.15.4",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.33",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.1",
+        "rss": "^1.2.2"
       },
       "devDependencies": {
         "@babel/core": "^7.12.13",
@@ -35,6 +36,7 @@
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.25",
         "@types/node-fetch": "^2.5.8",
+        "@types/rss": "0.0.28",
         "@typescript-eslint/eslint-plugin": "^4.15.0",
         "@typescript-eslint/parser": "^4.15.0",
         "babel-core": "^7.0.0-bridge.0",
@@ -2495,6 +2497,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
+    "node_modules/@types/rss": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/rss/-/rss-0.0.28.tgz",
+      "integrity": "sha512-Kymd0BI1tBOSwOwCN5Y8dtlJegTIF+izS8tJETiivJ7qAJGHhnuZjiunXWqBkgv6dg0ZZWyf0kEfMgkr4YWJzg==",
+      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.3",
@@ -13683,6 +13691,34 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "dependencies": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      }
+    },
+    "node_modules/rss/node_modules/mime-db": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/rss/node_modules/mime-types": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+      "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+      "dependencies": {
+        "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -16695,6 +16731,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
+    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -18787,6 +18828,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
+    "@types/rss": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@types/rss/-/rss-0.0.28.tgz",
+      "integrity": "sha512-Kymd0BI1tBOSwOwCN5Y8dtlJegTIF+izS8tJETiivJ7qAJGHhnuZjiunXWqBkgv6dg0ZZWyf0kEfMgkr4YWJzg==",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.3",
@@ -27762,6 +27809,30 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+      "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+      "requires": {
+        "mime-types": "2.1.13",
+        "xml": "1.0.1"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.25.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+          "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+        },
+        "mime-types": {
+          "version": "2.1.13",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+          "requires": {
+            "mime-db": "~1.25.0"
+          }
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -30154,6 +30225,11 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,8 @@
     "ical-generator": "^1.15.4",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "rss": "^1.2.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.13",
@@ -40,6 +41,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.25",
     "@types/node-fetch": "^2.5.8",
+    "@types/rss": "0.0.28",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "@typescript-eslint/parser": "^4.15.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/web/components/campus-news-card.vue
+++ b/web/components/campus-news-card.vue
@@ -8,7 +8,7 @@
     <v-card-text>
       <v-list dense>
         <div
-          v-for="item in campusNews.slice(0, 5)"
+          v-for="item in campusNews"
           :key="item.link"
           class="list-tile"
         >
@@ -21,7 +21,7 @@
           </a>
           <br>
           <span :class="['grey--text', {'text--darken-1': !isDark, 'text--lighten-1': isDark }]">
-            {{ item.source }}.
+            {{ shortname(item.source) }}.
           </span>
           <span>{{ item.text }}</span>
           <br>
@@ -36,6 +36,15 @@ import { mapState, mapActions } from 'vuex';
 
 export default {
   name: 'CampusNewsCard',
+  data () {
+    const availableSources = [
+      { description: 'Campus 38', shortname: 'Campus38', path: 'campus38' },
+      { description: 'Ostfalia Campus', shortname: 'Ostfalia', path: 'campus' }
+    ];
+    return {
+      availableSources
+    }
+  },
   computed: {
     ...mapState({
       campusNews: (state) => state.news.campusNews,
@@ -50,6 +59,9 @@ export default {
     }
   },
   methods: {
+    shortname (path) {
+      return this.availableSources.filter(source => source.path === path)[0].shortname;
+    },
     ...mapActions({
       loadCampusNews: 'news/loadCampusNews'
     })

--- a/web/components/faculty-news-card.vue
+++ b/web/components/faculty-news-card.vue
@@ -34,7 +34,7 @@
 
     <select-dialog
       :open.sync="dialogOpen"
-      :items="availableSoures"
+      :items="availableSources"
       :selected.sync="selectedItem"
       title="Quelle auswählen"
     />
@@ -51,22 +51,30 @@ export default {
     SelectDialog
   },
   data () {
-    const availableSoures = [
+    const availableSources = [
+      { description: 'Campus Wolfenbüttel', title: 'aus Wolfenbüttel', path: 'wf' },
+      { description: 'Campus Wolfsburg', title: 'aus Wolfsburg', path: 'wob' },
+      { description: 'Campus Suderburg', title: 'aus Suderburg', path: 'sud' },
       { description: 'Fakultät Elektrotechnik', title: 'aus der E-Technik', path: 'e' },
       { description: 'Fakultät Recht', title: 'aus dem Recht', path: 'r' },
-      { description: 'Fakultät Versorgungstechnik', title: 'aus der Versorgungstechnik', path: 'v' },
-      { description: 'Standort Wolfenbüttel', title: 'aus Wolfenbüttel', path: 'wf' },
-      { description: 'Standort Wolfsburg', title: 'aus Wolfsburg', path: 'wob' },
-      { description: 'Standort Suderburg', title: 'aus Suderburg', path: 'sud' }];
+      { description: 'Fakultät Soziale Arbeit', title: 'aus der sozialen Arbeit', path: 'r' }];
 
     return {
       dialogOpen: false,
-      availableSoures
+      availableSources
     }
   },
   computed: {
     selectedItem: {
-      get () { return this.availableSoures.filter(source => source.path === this.faculty)[0]; },
+      get () {
+        let selectedItem = this.availableSources.filter(source => source.path === this.faculty)[0];
+        if (selectedItem == null) {
+          // Reset to default if invalid item is used for some reason. This way we avoid blocking the whole dashboard in edge cases.
+          selectedItem = this.availableSources[0];
+          this.setFaculty(selectedItem.path);
+        }
+        return selectedItem;
+      },
       set (value) { this.setFaculty(value.path); }
     },
     ...mapState({

--- a/web/components/faculty-news-card.vue
+++ b/web/components/faculty-news-card.vue
@@ -14,7 +14,7 @@
     <v-card-text class="card-text-padding">
       <v-list dense>
         <div
-          v-for="item in news.slice(0, 2)"
+          v-for="item in facultyNews"
           :key="item.link"
           class="list-tile"
         >
@@ -42,7 +42,7 @@
 </template>
 
 <script>
-import { mapState, mapActions, mapMutations } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import SelectDialog from './select-dialog.vue'
 
 export default {
@@ -51,9 +51,10 @@ export default {
     SelectDialog
   },
   data () {
-    const availableSoures = [{ description: 'Fakultät Informatik', title: 'aus der Informatik', path: 'i' },
+    const availableSoures = [
       { description: 'Fakultät Elektrotechnik', title: 'aus der E-Technik', path: 'e' },
       { description: 'Fakultät Recht', title: 'aus dem Recht', path: 'r' },
+      { description: 'Fakultät Versorgungstechnik', title: 'aus der Versorgungstechnik', path: 'v' },
       { description: 'Standort Wolfenbüttel', title: 'aus Wolfenbüttel', path: 'wf' },
       { description: 'Standort Wolfsburg', title: 'aus Wolfsburg', path: 'wob' },
       { description: 'Standort Suderburg', title: 'aus Suderburg', path: 'sud' }];
@@ -64,11 +65,8 @@ export default {
     }
   },
   computed: {
-    news () {
-      return Object.keys(this.facultyNews).length > 0 ? this.facultyNews[this.faculty] : [];
-    },
     selectedItem: {
-      get () { return this.availableSoures.filter(source => source.path == this.faculty)[0]; },
+      get () { return this.availableSoures.filter(source => source.path === this.faculty)[0]; },
       set (value) { this.setFaculty(value.path); }
     },
     ...mapState({
@@ -85,9 +83,7 @@ export default {
   },
   methods: {
     ...mapActions({
-      loadNews: 'news/loadFacultyNews'
-    }),
-    ...mapMutations({
+      loadNews: 'news/loadFacultyNews',
       setFaculty: 'news/setFaculty'
     })
   }

--- a/web/components/faculty-news-card.vue
+++ b/web/components/faculty-news-card.vue
@@ -57,7 +57,7 @@ export default {
       { description: 'Campus Suderburg', title: 'aus Suderburg', path: 'sud' },
       { description: 'Fakultät Elektrotechnik', title: 'aus der E-Technik', path: 'e' },
       { description: 'Fakultät Recht', title: 'aus dem Recht', path: 'r' },
-      { description: 'Fakultät Soziale Arbeit', title: 'aus der sozialen Arbeit', path: 'r' }];
+      { description: 'Fakultät Soziale Arbeit', title: 'aus der sozialen Arbeit', path: 's' }];
 
     return {
       dialogOpen: false,

--- a/web/store/news.js
+++ b/web/store/news.js
@@ -17,24 +17,23 @@ export const mutations = {
 }
 
 export const actions = {
-  async loadFacultyNews ({ commit }) {
-    const faculties = ['i', 'r', 'e', 'wf', 'wob', 'sud'];
+  async loadFacultyNews ({ commit, state }) {
     try {
-      const news = await this.$axios.$get('/api/news/faculty');
-
-      const newsMap = {};
-      faculties.forEach((faculty) => { newsMap[faculty] = news.filter((article) => article.source == faculty) });
-
-      commit('setFacultyNews', newsMap);
+      const news = await this.$axios.$get(`/api/news/${state.faculty}`, { params: { limit: 2 } });
+      commit('setFacultyNews', news);
     } catch (error) {
       commit('enqueueError', 'News: API-Verbindung fehlgeschlagen (Fakultät-News)', { root: true });
       console.error('error during News API call (Fakultät-News)', error.message);
     }
   },
+  async setFaculty ({ commit, dispatch }, faculty) {
+    commit('setFaculty', faculty);
+    dispatch('loadFacultyNews');
+  },
   async loadCampusNews ({ commit }) {
+    const campusSelectors = ['campus', 'campus38'];
     try {
-      const campusNews = await this.$axios.$get('/api/news/campus');
-
+      const campusNews = await this.$axios.$get(`/api/news/${campusSelectors.join(',')}`, { params: { limit: 5 } });
       commit('setCampusNews', campusNews);
     } catch (error) {
       commit('enqueueError', 'News: API-Verbindung fehlgeschlagen (Ostfalia-News)', { root: true });


### PR DESCRIPTION
Teil 1 für #456. Die Dashboard-Änderungen werden in einem zukünftigen PR kommen, der hier ist quasi backend-only.

* Alle Ostfalia-News werden (wie vorher nur die Campus-News) über den speziellen Ostfalia-Endpoint bezogen. Dadurch werden jetzt fast alle Fakultäten supportet und es gibt insgesamt weniger Wartungsaufwand.
* Der API-Endpoint erwartet jetzt eine Liste von News-Typen, die geladen werden sollen. Dadurch werden zB die API-Responses für die Startseite deutlich verkleinert, da nur die notwendigen News geladen werden.
* RSS-Feed-Support mittels angehängtem `.rss` im API-Call.
* Kürzen der News wurde verbessert

Supported: `r`, `b`, `k`, `h`, `f`, `g`, `w`, `e`, `s`, `wob`, `wf`, `sud`, `sz`, `campus`, `campus38`. Informatik (und einige andere) sind nicht dabei, da die Fakultäten ein eigenes Format nutzen. Die Informatik-News funktionieren deshalb auch schon seit einer Weile nicht mehr.

In der UI hat sich fast nichts verändert, außer dass die News besser gekürzt werden und Informatik offiziell entfernt wurde.