### PR TITLE
Fix a critical bug where the start and end date of cached events were corrupted

### DIFF
--- a/server/lib/SplusApi.ts
+++ b/server/lib/SplusApi.ts
@@ -103,8 +103,8 @@ export async function getUniqueEvents (timetable: TimetableRequest): Promise<Eve
   // Filter unique events
   const uniqueEvents = [...new Set(allEvents.map(obj => obj.id))] // search all unique IDs
     .map(id => {
-      // map IDs back to events
-      const matchingEvent = allEvents.find(evt => evt.id == id);
+      // map IDs back to events, but copy by value first so we don't modify existing cache objects!
+      const matchingEvent = allEvents.slice().find(evt => evt.id == id);
       // clear end and start since this is just one of the random events for this ID
       matchingEvent.start = null;
       matchingEvent.end = null;


### PR DESCRIPTION
Durch den neuen unique lecture endpoint (#455) wurde ein kritischer Bug hinzugefügt, bei dem ich die Start- und End-Daten einiger Events im Cache genullt habe. 

Das Nullen an sich ist zwar beabsichtigt, aber die Kombination aus der Caching-Logik und mein Unwissen über javascripts pass by reference für diese gecachten Event-Objekte hat dafür gesorgt, dass der Cache corrupted wird. 

Konkret wurden die Events der ersten Woche nicht mehr alle angezeigt, sobald man einmal einen personalisierten Plan erstellt hat. Das hält so lange an, bis der Cache erneuert wird. Als Workaround hab ich die Cache-Dauer temporär auf 15 Minuten reduziert, aber das hier sollte trotzdem so schnell wie möglich gemergt werden.

Gefixt habe ich das hier, indem das Array mittels slice() zuerst kopiert wird und danach erst weiter modifiziert. Ich habe keine weiteren Fälle gefunden, wo ich den gleichen Fehler gemacht habe. Wundern würde es mich aber nicht, da es für mich unexpected war, dass ich die Objekte "direkt im Cache" modifizieren kann.

