### PR TITLE
Automatically update timetables (daily) with sked-parser and github actions

### DIFF
--- a/.github/workflows/timetables.yml
+++ b/.github/workflows/timetables.yml
@@ -1,0 +1,39 @@
+name: Timetable sync
+
+on:
+ schedule:
+   - cron: '0 18 * * *' # once per day so we don't spam ostfalia servers too much
+ workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install sked-parser
+        run: python -m pip install git+https://github.com/SplusEins/sked_parser.git
+      - name: Run sked-parser
+        run: sked-parser -o web/assets/timetables.json -o server/assets/timetables.json
+        env:
+          OSTFALIA_USER: ${{ secrets.OSTFALIA_USER }}
+          OSTFALIA_PASS: ${{ secrets.OSTFALIA_PASS }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ github.token }}
+          commit-message: Updated timetables with sked-parser
+          branch: actions/update-timetables
+          title: 'Sync timetables.json with Ostfalia'
+          body: |
+            Updated timetables with sked-parser automatically using [sked-parser](https://github.com/SplusEins/sked_parser).
+            Check the Action output for any warnings that occured while parsing.
+            More Information can be found [in the docs](https://spluseins-i.ostfalia.de/docs/semesterbeginn.html#aktualisierung-der-plane)
+            *This PR will be force-pushed everytime new changes are available or when the master branch has been updated.*
+          labels: automated
+          assignees: l3d00m


### PR DESCRIPTION
*#465 nochmal richtig geöffnet*

Die Github Action läuft einmal pro Tag und führt den sked-parser aus. Anschließend wird ein PR geöffnet, damit die Changes reviewed werden können. Sollte noch ein PR offen sein, wird stattdessen der existierende PR bei Änderungen force gepusht. Siehe auch https://github.com/l3d00m/SplusEins/pull/3

Vorteile:
* Wir kriegen direkt mit, wenn sich URLs der Pläne verändern
* Mehr Automatisierung 🥳

Nachteile:
* Wenn der PR offen ist und man noch manuell nacharbeitet (weil irgendein Label oder so nicht stimmt, passiert gelegentlich mal), wird der PR nach dem Merge neu geöffnet, da dann ja Changes vorhanden sind. Das kann man IMO nicht wirklich verbessern, außer dass man halt einfach den Workflow deaktiviert, sollte das zu sehr stören.

Idee aus #464 ♥️