### PR TITLE
Refresh next lecture on dashboard automatically and keep showing it for a few minutes after start

### DIFF
--- a/web/components/upcoming-lectures-card.vue
+++ b/web/components/upcoming-lectures-card.vue
@@ -76,10 +76,10 @@ export default {
           title: event.title,
           room: event.location,
           lecturer: event.meta.organiserName,
-          start: moment(event.start).hour(parseInt(event.begin / 1)).minute(event.begin % 1 * 60)
+          start: moment(event.start)
         }))
       // Find the next event or use the current event if it's only x minutes ago
-        .filter(event => event.start.valueOf() - this.now > -10 * 60 * 1000)
+        .filter(event => event.start.valueOf() - this.now > -15 * 60 * 1000)
         .sort((a, b) => a.start.valueOf() - b.start.valueOf());
       return possibleEvents[0] !== undefined ? possibleEvents[0] : undefined;
     }
@@ -95,7 +95,7 @@ export default {
     if (this.subscribedTimetable.id) {
       this.load();
     }
-    // Refresh current date so the nextEvent is reevaluated every now an then without a manual refresh from the user
+    // Refresh current date so the nextEvent is reevaluated every now and then without a manual refresh from the user
     this.refreshTimer = setInterval(() => (this.now = Date.now()), 60 * 1000)
   },
   destroyed () {

--- a/web/components/upcoming-lectures-card.vue
+++ b/web/components/upcoming-lectures-card.vue
@@ -11,18 +11,18 @@
       </v-btn>
     </v-card-title>
 
-    <v-card-text v-if="nextEvent != undefined">
+    <v-card-text v-if="nextEvent !== undefined">
       <b>{{ nextEvent.title }} {{ nextEvent.lecturer }}</b>
       <br>
       Datum: {{ nextEvent.start.format('dddd, DD.MM.YYYY') }}
       <br>
-      Uhrzeit: {{ nextEvent.start.hour() }}:{{ nextEvent.start.minute() == 0? "00" : nextEvent.start.minute() }} Uhr
+      Uhrzeit: {{ nextEvent.start.hour() }}:{{ nextEvent.start.minute() === 0? "00" : nextEvent.start.minute() }} Uhr
       <br>
       <span v-if="!!nextEvent.room">
         Raum: <span v-html="nextEvent.room" />
       </span>
     </v-card-text>
-    <v-card-text v-else-if="hasSubscribableTimetables && nextEvent == undefined">
+    <v-card-text v-else-if="hasSubscribableTimetables && nextEvent === undefined">
       <i>Keine weiteren Vorlesungen in dieser Woche!</i>
     </v-card-text>
     <v-card-text v-else>
@@ -101,9 +101,10 @@ export default {
           lecturer: event.meta.organiserName,
           start: moment(event.start).hour(parseInt(event.begin / 1)).minute(event.begin % 1 * 60)
         }))
-        .filter(event => event.start.valueOf() - moment().valueOf() > 0)
+      // Find the next event or use the current event if it's only x minutes ago
+        .filter(event => event.start.valueOf() - moment().valueOf() > -10 * 60 * 1000)
         .sort((a, b) => a.start.valueOf() - b.start.valueOf());
-      return possibleEvents[0] != undefined ? possibleEvents[0] : undefined;
+      return possibleEvents[0] !== undefined ? possibleEvents[0] : undefined;
     },
     load () {
       this.setUpcomingLecturesTimetable(this.subscribedTimetable);


### PR DESCRIPTION
* Nächste Vorlesung auf dem Dashboard wird jede Minute mittels setInterval erneuert (ähnlich wie beim Bus-Plan)
* Vorlesung wird auch 15 Minuten nach Start angezeigt (wenn man zu spät kommt :D)
* Bisschen refactored, damit vue `computed` statt `watch` genutzt wird

Gleich live auf https://staging.spluseins.de/