### PR TITLE
Fix SplusEins down/timeout because OpenMensa is currently down

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,7 +22,8 @@
         "moment-timezone": "^0.5.33",
         "node-fetch": "^2.6.1",
         "rss": "^1.2.2",
-        "sanitize-html": "^2.3.2"
+        "sanitize-html": "^2.3.2",
+        "timeout-signal": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.13",
@@ -3151,6 +3152,17 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -7448,6 +7460,14 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -15369,6 +15389,17 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/timeout-signal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
+      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
@@ -19619,6 +19650,14 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -23166,6 +23205,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.0.0",
@@ -29428,6 +29472,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "timeout-signal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-1.1.0.tgz",
+      "integrity": "sha512-fuWY4tM1njcHCiOB7XkTmP0EOxzBkPbuQwPN+ZCzM6G0Tj4fMVgEffG/OPgiNUX48o+FhQEa2Oh4qjEDBCy5WQ==",
+      "requires": {
+        "abort-controller": "^3.0.0"
       }
     },
     "timers-browserify": {

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,8 @@
     "moment-timezone": "^0.5.33",
     "node-fetch": "^2.6.1",
     "rss": "^1.2.2",
-    "sanitize-html": "^2.3.2"
+    "sanitize-html": "^2.3.2",
+    "timeout-signal": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.13",

--- a/web/pages/bus.vue
+++ b/web/pages/bus.vue
@@ -86,10 +86,7 @@ export default {
     })
   },
   mounted () {
-    if (this.lazyLoad) {
-      // static build -> no mensa plan is in the store
-      this.load()
-    }
+    this.load()
     this.refreshTimer = setInterval(() => this.load(), 60000)
   },
   destroyed () {

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapMutations } from 'vuex';
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex';
 import UpcomingLecturesCard from '../components/upcoming-lectures-card.vue';
 import QuickAccessCard from '../components/quick-access-card.vue';
 import MensaCard from '../components/mensa-card.vue';
@@ -129,9 +129,15 @@ export default {
       ]
     };
   },
+  mounted () {
+    this.load();
+  },
   methods: {
     ...mapMutations({
       setSidenav: 'ui/setSidenav'
+    }),
+    ...mapActions({
+      load: 'mensa/load'
     })
   },
   middleware: 'cached'

--- a/web/pages/mensa.vue
+++ b/web/pages/mensa.vue
@@ -140,10 +140,7 @@ export default {
     }
   },
   mounted () {
-    if (this.lazyLoad) {
-      // static build -> no mensa plan is in the store
-      this.load();
-    }
+    this.load();
   },
   methods: {
     ...mapActions({

--- a/web/store/index.js
+++ b/web/store/index.js
@@ -45,8 +45,6 @@ export const actions = {
     }
 
     await Promise.all([
-      dispatch('mensa/load'),
-      dispatch('bus/load'),
       dispatch('news/loadCampusNews'),
       dispatch('news/loadFacultyNews')
     ]);


### PR DESCRIPTION
SplusEins is currently down/times out since today because OpenMensa is down (to be precise, OpenMensa is still accepting requests, but all requests are timing out).

This leads to the following situation: The server side OpenMensa request had no timeout configured, so it ran unitl the OS limit (usually 2-5 minutes until it was reached). 

SplusEins SSR depended on the API for the first load because it calls `mensa/load` in `nuxtServerInit` of`store/index.js`.

Fixes:

* server side timeout of 3 seconds for all OpenMensa requests
* Load mensa (and bus for any future issues) on client side only, do not block for it 