### PR TITLE
Use nuxt as proxy for API and docs instead of manually configured nginx

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,118 +6,95 @@ Die Ordner `server/`, `web/` und `docs/` enthalten Projekte, die auf [Heroku](ht
 
 Nach der Einrichtung des Dokku-Servers (siehe unten) muss zum Deployen bei neuen Änderungen nur folgendes ausgeführt werden: `git push web` für das Frontend, `git push api` für das Backend und `git push docs` für diese Dokumentation.
 
-Die drei Projekte landen mit Dokku dann in einzelnen Containern und können auf bestimmten `localhost`-Ports angesprochen werden. Damit diese von extern auf den richtigen Pfaden (das Backend auf `https://domain.de/api/`, das Frontend regulär auf `https://domain.de`) angesprochen werden können, wird mittels `nginx` ein Reverse-Proxy vorgeschaltet, der die Pfade an die richtigen lokalen Ports (bzw. die dahinterstehenden Dokku-Container) weiterleitet.
-
 ### Einrichten der lokalen Maschine fürs Deployment
 
 1. Das Spluseins-Repository clonen.
 2. Einrichten der fürs Deployment notwendigen git Remotes im geklonten Repository. Dafür sind Zugriffsrechte über SSH Public Keys auf dem Server notwendig.
-
    ```bash
    git remote add web dokku@SERVER_IP_ADRESSE:web
    git remote add api dokku@SERVER_IP_ADRESSE:api
    git remote add docs dokku@SERVER_IP_ADRESSE:docs
    ```
-
    ::: tip
    Hierbei ist wichtig, dass der Teil hinter dem Doppelpunkt in der Datei `.dokku-monorpo` referenziert wird. Der Remote-Name (nach `remote add`) darf beliebig gewählt werden.
    :::
-
 3. Deployen der Module mittels `git push NAME_DER_REMOTE`, also z.B. mit der vorherigen Einrichtung `git push web`, um das Frontend zu deployen. Dokku sorgt dann automatisch dafür, dass ein Node-Build-Environment auf dem Server angelegt wird, die Applikation gebaut wird und dann inklusive Hot-Swap deployt wird. Das spart sehr viel Arbeit im Vergleich zu manuellen Deployments.
 
 ### Aufsetzen des Dokku-Servers
 
-1. Installation von Dokku [nach Anleitung](http://dokku.viewdocs.io/dokku/getting-started/installation/). Im anschließenden Web-Setup den **Haken bei VHOSTS entfernen**, da nicht mit den Subdomains gearbeitet wird. Den Servernamen auf `localhost` setzen.
+1. Installation von Dokku [nach Anleitung](http://dokku.viewdocs.io/dokku/getting-started/installation/). Im anschließenden Web-Setup **VHOSTS aktivieren**.
 2. Installation des [dokku-monorepo](https://github.com/notpushkin/dokku-monorepo/)-Plugin mit `dokku plugin:install https://gitlab.com/notpushkin/dokku-monorepo`.
-3. Anlegen der Dokku-Container für die einzelnen Module:
+3. Einmal **alle** Module mit der lokalen Maschine deployen, wie im vorherigen Kapitel erklärt. Dabei werden die Container automatisch erzeugt.
+4. Netzwerk-Konfiguration für Dokku anlegen, damit die Container untereinander kommunizieren können.
+   ```bash
+   dokku network:create spluseins
+   dokku network:set web attach-post-deploy spluseins
+   dokku network:set api attach-post-deploy spluseins
+   dokku network:set docs attach-post-deploy spluseins
+   dokku network:rebuildall
+   dokku ps:restart web
+   dokku ps:restart api
+   dokku ps:restart docs
+   ```
+5. Setzen der Umgebungsvariablen für die Module, siehe [Umgebungsvariablen](./konfiguration.md#umgebungsvariablen). Besonders wichtig sind die `HOST`- und `API_URL`-Variablen, diese müssen wie folgt **auf dem Server** gesetzt werden:
+   ```bash
+   dokku domains:add web spluseins.de spluseins-i.ostfalia.de
+   dokku config:set web API_URL=http://api.web:5000/ DOCS_URL=http://docs.web:5000/
+   ```
+   ::: tip
+   Port 5000 ist der Standard für die Anwendung **innerhalb** des Dokku-Containers, welcher mit `APP_NAME.web` angesprochen werden kann. Die `web`-Anwendung bringt mit Nuxt einen Proxy mit, der dann Requests von `/api` und `/docs` auf die URLs in den Umgebungsvariablen weiterleitet.
+   :::
+6. SSL-Zertifikat angelegen:
+   ```bash
+   dokku domains:add frontend www.spluseins.de # wichig für redirect im nächsten schritt
+   dokku letsencrypt:enable frontend
+   dokku domains:remove frontend www.spluseins.de # domain wieder entfernen
+   dokku letsencrypt:cron-job --add
+   ```
+7. Nginx: Weiterleitungen von www auf non-www anlegen, außerdem Catch-All hinzufügen. Dafür folgende Datei anlegen `/etc/nginx/conf.d/00-default-vhost.conf` mit Inhalt:
 
-```
-dokku apps:create web
-dokku apps:create api
-dokku apps:create docs
-```
+   ```nginx
+   server {
+       listen 80 default_server;
+       listen [::]:80 default_server;
 
-4. Einmal mit der lokalen Maschine deployen, wie im vorherigen Kapitel erklärt. Sonst werden die nachfolgenden Einstellungen später beim ersten Deploy wieder überschrieben.
-5. Ports der einzelnen Module/Container wie folgt definieren (werden sonst zufällig gesetzt).
+       server_name _;
+       access_log off;
+       return 410;
+   }
 
-```
-dokku proxy:ports-set web http:50000:5000
-dokku proxy:ports-set api http:50001:5000
-dokku proxy:ports-set docs http:50002:5000
-```
+   server {
+       listen 443 ssl;
+       listen [::]:443 ssl;
 
-::: tip
-Port 5000 ist der Standard für die Anwendung **innerhalb** des Dokku-Containers, der dann auf einen Port des Hosts weitergeleitet werden muss. Diese entsprechenden Host-Ports (z.B. hier 50002 für `docs`) sind frei wählbar und müssen nur wieder innerhalb des nginx Reverse Proxy weiter unten referenziert werden.
-:::
+       server_name _;
+       ssl_certificate /home/dokku/web/letsencrypt/certs/current/certificates/spluseins.de.crt;
+       ssl_certificate_key /home/dokku/web/letsencrypt/certs/current/certificates/spluseins.de.key;
+       return 410;
+   }
 
-6. Setzen der Umgebungsvariablen für die Module, siehe [Umgebungsvariablen](./konfiguration.md#umgebungsvariablen). Besonders wichtig sind die `HOST`-Variablen, diese müssen wie folgt **auf dem Server** gesetzt werden:
+   server {
+       listen 80;
+       listen [::]:80;
 
-```
-dokku config:set web HOST=0.0.0.0
-dokku config:set api HOST=0.0.0.0
-dokku config:set docs HOST=0.0.0.0
-```
+       server_name www.spluseins.de;
+       return 301 https://spluseins.de$request_uri;
+   }
 
-::: warning
-Ohne das Setzen der Host-Variablen funktioniert der Setup nicht, da die Applikationen standardmäßig nur auf `localhost` innerhalb des Containers gebindet werden.
-:::
+   server {
+       listen 443 ssl;
+       listen [::]:443 ssl;
 
-7. Anlegend der nginx-Konfiguration für den notwendigen Reverse Proxy als `/etc/nginx/conf.d/00-default-vhost.conf`:
-
-```nginx
-server {
-  server_name _;
-  listen 80 default_server;
-  listen [::]:80 default_server;
-  access_log  /var/log/nginx/dokku-access.log;
-  error_log   /var/log/nginx/dokku-error.log;
-
-  # www subdomain entfernen
-  if ($host ~* ^www\.(.*)) {
-    set $host_without_www $1;
-    rewrite ^(.*) https://$host_without_www$1 permanent;
-  }
-
-  location / {
-    proxy_pass http://localhost:50000;
-    include /etc/nginx/proxy-params.conf;
-  }
-  location /api {
-    proxy_pass http://localhost:50001;
-    include /etc/nginx/proxy-params.conf;
-  }
-  location /docs {
-    rewrite ^/docs/(.*) /$1  break;
-    proxy_pass http://localhost:50002;
-    include /etc/nginx/proxy-params.conf;
-  }
-}
-map $http_upgrade $connection_upgrade {
-    # Used inside the included proxy params configuration (for websockets)
-    default upgrade;
-    ''      close;
-}
-```
-
-8. Die Datei `/etc/nginx/proxy-params.conf` wird von der angelegten Reverse-Proxy-Konfiguration referenziert und muss deshalb mit folgendem Inhalt angelegt werden. Diese setzt einige allgemeine Einstellungen für jeden Reverse Proxy.
-
-```nginx
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection $connection_upgrade;
-proxy_http_version 1.1;
-proxy_set_header X-REAL-IP $remote_addr;
-proxy_buffering off;
-```
-
-9. Die Konfiguration kann mit `nginx -t` getestet werden und wird mit `sudo systemctl restart nginx` aktiv.
-10. Wie im vorherigen Kapitel beschrieben, muss jetzt mit einer lokalen Maschine deployt werden. Danach sollte SplusEins erreichbar sein.
-    ::: tip
-    Mittels des Let's Encrypt Bots kann zudem sehr einfach ein SSL-Zertifikat erstellt und zu nginx hinzugefügt werden: `sudo certbot --nginx -d spluseins.de -d www.spluseins.de -d spluseins-i.ostfalia.de` ([ausführliche Anleitung](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-20-04-de)).
-    :::
+       server_name www.spluseins.de;
+       ssl_certificate /home/dokku/web/letsencrypt/certs/current/certificates/spluseins.de.crt;
+       ssl_certificate_key /home/dokku/web/letsencrypt/certs/current/certificates/spluseins.de.key;
+       return 301 https://spluseins.de$request_uri;
+   }
+   ```
 
 ## Manuell
 
-[Siehe README](https://github.com/SplusEins/SplusEins) zum Ausführen der Module im Development-Modus. Die Dokumentation der einzelnen Umgebungsvariablen befindet sich im [Konfiguration-Abschnitt](konfiguration.md#umgebungsvariablen).
+[Siehe README](https://github.com/SplusEins/SplusEins) zum Ausführen der Module im Development-Modus. Die Dokumentation der einzelnen Umgebungsvariablen befindet sich im [Konfiguration-Abschnitt](konfiguration.md#umgebungsvariablen) bzw. in der vorherigen Anleitung zu Dokku.
 
 Alle Module (`docs`, `server`, `web`) können dazu **jeweils** mit den folgenden Befehlen in den produktiven Betrieb gebracht werden:
 

--- a/docs/konfiguration.md
+++ b/docs/konfiguration.md
@@ -11,7 +11,8 @@ Sowohl Frontend als auch Backend können bzw. müssen über Umgebungsvariablen k
 ### Frontend
 
 - `HOST`: Host (Domain oder IP) des Servers (Default: `127.0.0.1`)
-- `API_URL`: URL der API ohne /api Suffix (Default: `https://spluseins.de/`)
+- `API_URL`: (Lokale) URL der API ohne `/api` Suffix (z.B. `http://localhost:50001/`), alle Requests zu `/api` werden (von Nuxt als Proxy) zu dieser URL weitergeleitet.
+- `DOCS_URL`: (Lokale) URL der Dokumentation (z.B. `http://localhost:50002/`), alle Requests zu `/docs` werden (von Nuxt als Proxy) zu dieser URL weitergeleitet.
 - `PAGE_CACHE_SECONDS`: Cache-Dauer in Sekunden für gerenderte Nuxt-Seiten (Default: `600`)
 - `PROTECTED_INFORMATION`: Namen der Team-Mitglieder für das Impressum und die Datenschutz-Seite
 

--- a/web/.vscode/launch.json
+++ b/web/.vscode/launch.json
@@ -34,7 +34,8 @@
                 "program": "${workspaceFolder}/node_modules/nuxt/bin/nuxt.js"
             },
             "env": {
-                "API_URL": "http://127.0.0.1:3001"
+                "API_URL": "http://127.0.0.1:3001/",
+                "DOCS_URL": "http://127.0.0.1:8080/"
             }
         }
     ],

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -63,6 +63,7 @@ export default {
   modules: [
     // https://github.com/nuxt-community/axios-module#usage
     '@nuxtjs/axios',
+    '@nuxtjs/proxy',
     // https://pwa.nuxtjs.org/
     '@nuxtjs/pwa',
     // https://github.com/nuxt-community/dayjs-module
@@ -72,8 +73,13 @@ export default {
   ** Axios module configuration
   */
   axios: {
-
+    proxy: true
   },
+  proxy: { // https://axios.nuxtjs.org/options/#proxy
+    '/api': { target: process.env.API_URL },
+    '/docs': { target: process.env.DOCS_URL, pathRewrite: { '^/docs': '' } }
+  },
+
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nuxtjs/axios": "^5.13.1",
         "@nuxtjs/dayjs": "^1.3.1",
+        "@nuxtjs/proxy": "^2.1.0",
         "@nuxtjs/pwa": "^3.3.5",
         "chroma-js": "2.1.0",
         "nuxt": "^2.15.4",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.13.1",
     "@nuxtjs/dayjs": "^1.3.1",
+    "@nuxtjs/proxy": "^2.1.0",
     "@nuxtjs/pwa": "^3.3.5",
     "chroma-js": "2.1.0",
     "nuxt": "^2.15.4",


### PR DESCRIPTION
Neues Deployment mit dem nuxt-Proxy Modul, anstatt das selber mit nginx zu konfigurieren. Ist bereits online und läuft, der PR hier ist nur noch zu Doku-Zwecken.

Vorteil: Das Deployment ist deutlich leichter und man kann mehr die nativen Dokku-Features nutzen und hat nicht mehr diesen etwas merkwürdigen doppelten Nginx Reverse Proxy, wie wir es vorher hatten.

Außerdem vermeiden wir damit CORS-Probleme, die wir vorher hatten, da beim Aufruf von spluseins.de die API unter spluseins-i.ostfalia.de/api aufgerufen wurde.