### PR TITLE
Catch OpenMensa timeouts properly and display better mensa errors

### DIFF
--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const serverConfig = {
   mode: process.env.NODE_ENV,
@@ -23,6 +24,22 @@ const serverConfig = {
     extensions: ['.ts', '.js'],
     mainFields: ['main']
   }
+};
+
+// from https://github.com/node-fetch/node-fetch/issues/784#issuecomment-786305770
+// keep_classnames is required to workaround node-fetch "Expected signal to be an instanceof AbortSignal" error
+// we are using an AbortSignal through "timeout-signal" in controllers/mensa.ts
+serverConfig.optimization = {
+  minimizer: [
+    new TerserPlugin({
+      cache: true,
+      parallel: true,
+      terserOptions: {
+        keep_classnames: /AbortSignal/,
+        keep_fnames: /AbortSignal/
+      }
+    })
+  ]
 };
 
 module.exports = [serverConfig];

--- a/web/pages/index.vue
+++ b/web/pages/index.vue
@@ -130,8 +130,7 @@ export default {
     };
   },
   mounted () {
-    // TODO WS21: sobald die Mensa wieder offen hat, auskommentieren damit Mensa-Pläne auch auf Startseite angezeigt werden
-    // this.loadMensa();
+    this.loadMensa();
   },
   methods: {
     ...mapMutations({


### PR DESCRIPTION
timeouts are now working properly if openmensa should be down again, also we are sending some more helpful status codes