### PR TITLE
Improve error detection and handling throughout SplusEins

### DIFF
--- a/server/lib/SplusApi.ts
+++ b/server/lib/SplusApi.ts
@@ -46,19 +46,23 @@ async function skedRequest (timetable: TimetableRequest): Promise<string> {
 
   const url = SKED_BASE + timetable.skedPath;
   console.log(`Url for ${timetable.id} is ${url}`)
-  let error;
+  let errorMsg = '';
   for (let attempt = 0; attempt < 3; attempt++) {
     const res = await fetch(url, { headers });
     if (res.ok) {
       return res.text()
     }
 
-    error = `Sked error for ${timetable.id}: ${res.statusText} (attempt ${attempt})`;
-    console.error(error);
+    if (res.status < 500) {
+      // Client side error, throw directly
+      throw new Error(`${res.status}: Ostfalia Sked replied "${res.statusText}"`);
+    }
+    errorMsg = `${res.status} Sked error for ${timetable.id}: ${res.statusText} (attempt ${attempt})`;
+    console.error(errorMsg);
     await sleep(100);
   }
 
-  throw new Error(error);
+  throw new Error(errorMsg);
 }
 
 /**

--- a/web/layouts/error.vue
+++ b/web/layouts/error.vue
@@ -32,7 +32,8 @@
             <div
               v-if="error.statusCode == 404"
             >
-              Diese Seite gibt es leider nicht...
+              <span v-if="error.response"> {{ error.response.data }}  </span>
+              <span v-else> Diese Seite gibt es leider nicht...</span>
             </div>
             <div
               v-if="error.statusCode == 500"

--- a/web/pages/plan/_timetable.vue
+++ b/web/pages/plan/_timetable.vue
@@ -35,7 +35,7 @@ export default {
     store.commit('splus/resetWeek', process.static);
 
     if (store.state.splus.schedule == undefined) {
-      error({ statusCode: 404, message: 'Plan existiert nicht' });
+      error({ statusCode: 404, message: 'Not found', response: { data: 'Dieser Plan existiert nicht (mehr)' } });
       return;
     }
 

--- a/web/store/bus.js
+++ b/web/store/bus.js
@@ -16,7 +16,8 @@ export const actions = {
       const response = await this.$axios.get('/api/bus');
       result = response.data;
     } catch (error) {
-      commit('enqueueError', 'Bus: API-Verbindung fehlgeschlagen', { root: true });
+      const errorCode = error.response ? error.response.status : 'unknown error'
+      commit('enqueueError', `Busplan konnte nicht geladen werden (${errorCode}).`, { root: true });
       console.error('error during Bus API call', error.message);
     }
 

--- a/web/store/mensa.js
+++ b/web/store/mensa.js
@@ -37,7 +37,8 @@ export const actions = {
       const response = await this.$axios.get('/api/mensa');
       result = response.data;
     } catch (error) {
-      commit('enqueueError', 'Mensa: API-Verbindung fehlgeschlagen', { root: true });
+      const errorCode = error.response ? error.response.status : 'unknown error'
+      commit('enqueueError', `Mensaplan konnte nicht geladen werden (${errorCode}).`, { root: true });
       console.error('error during Mensa API call', error.message);
     }
 

--- a/web/store/news.js
+++ b/web/store/news.js
@@ -22,7 +22,8 @@ export const actions = {
       const news = await this.$axios.$get(`/api/news/${state.faculty}`, { params: { limit: 2 } });
       commit('setFacultyNews', news);
     } catch (error) {
-      commit('enqueueError', 'News: API-Verbindung fehlgeschlagen (Fakultät-News)', { root: true });
+      const errorCode = error.response ? error.response.status : 'unknown error'
+      commit('enqueueError', `Fakultät-News konnten nicht geladen werden (${errorCode}).`, { root: true });
       console.error('error during News API call (Fakultät-News)', error.message);
     }
   },
@@ -36,7 +37,8 @@ export const actions = {
       const campusNews = await this.$axios.$get(`/api/news/${campusSelectors.join(',')}`, { params: { limit: 5 } });
       commit('setCampusNews', campusNews);
     } catch (error) {
-      commit('enqueueError', 'News: API-Verbindung fehlgeschlagen (Ostfalia-News)', { root: true });
+      const errorCode = error.response ? error.response.status : 'unknown error'
+      commit('enqueueError', `Campus-News konnten nicht geladen werden (${errorCode}).`, { root: true });
       console.error('error during News API call (Ostfalia-News)', error.message);
     }
   }

--- a/web/store/splus.js
+++ b/web/store/splus.js
@@ -297,10 +297,9 @@ export const actions = {
       commit('setLectures', lectures);
       commit('setEvents', events);
     } catch (error) {
-      if (error.response.status === 403) {
-        throw error;
-      }
-      commit('enqueueError', 'Stundenplan: API-Verbindung fehlgeschlagen', { root: true });
+      const errorCode = error.response ? error.response.status : 'unknown error'
+      if (errorCode === 404) throw error;
+      commit('enqueueError', `Stundenplan konnte nicht geladen werden (${errorCode}).`, { root: true });
       console.error('error during API call', error.message);
     }
   },
@@ -312,11 +311,9 @@ export const actions = {
       const events = await loadEvents(state.upcomingLecturesTimetable, dayjs(defaultWeek()).isoWeek(), this.$axios.$get);
       commit('setUpcomingEvents', events);
     } catch (error) {
-      if (error.response.status === 403) {
-        throw error;
-      }
-      commit('enqueueError', 'Stundenplan: API-Verbindung fehlgeschlagen', { root: true });
-      console.error('error during API call', error.message);
+      // don't show the error because this error is not critical on the start page and looks bad
+      // commit('enqueueError', 'Stundenplan: API-Verbindung fehlgeschlagen', { root: true });
+      console.error('Error during API call for upcoming events on index page', error.message);
     }
   },
   /**


### PR DESCRIPTION
* Detect sked errors and return appropriate status codes instead of 500 Internal Server Error (i.e. if a timetable is no longer available, just return 404)
* Error Snackbars in UI now have "simpler" texts, they display a simple error and the error status code
* 404 errors for timetables are now properly raised (so the nuxt error page is shown) and it says "plan nicht gefunden" instead of "diese seite gibt es leider nicht..."

live on https://staging.spluseins.de in short