### PR TITLE
Fix wrongly shown faculty news and always refresh bus + timetables

### DIFF
--- a/web/components/faculty-news-card.vue
+++ b/web/components/faculty-news-card.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex';
+import { mapState, mapActions, mapMutations } from 'vuex';
 import { mdiNewspaper } from '@mdi/js'
 
 export default {
@@ -81,13 +81,20 @@ export default {
       faculty: (state) => state.news.faculty
     })
   },
+  watch: {
+    faculty: function () {
+      this.loadNews();
+    }
+  },
   mounted () {
     // force load because server side might use wrong selected faculty for loading
     this.loadNews();
   },
   methods: {
     ...mapActions({
-      loadNews: 'news/loadFacultyNews',
+      loadNews: 'news/loadFacultyNews'
+    }),
+    ...mapMutations({
       setFaculty: 'news/setFaculty'
     })
   }

--- a/web/components/faculty-news-card.vue
+++ b/web/components/faculty-news-card.vue
@@ -78,15 +78,12 @@ export default {
     },
     ...mapState({
       facultyNews: (state) => state.news.facultyNews,
-      faculty: (state) => state.news.faculty,
-      lazyLoad: (state) => state.lazyLoad
+      faculty: (state) => state.news.faculty
     })
   },
   mounted () {
-    if (this.lazyLoad) {
-      // static build -> no news are in the store
-      this.loadNews();
-    }
+    // force load because server side might use wrong selected faculty for loading
+    this.loadNews();
   },
   methods: {
     ...mapActions({

--- a/web/components/spluseins-calendar.vue
+++ b/web/components/spluseins-calendar.vue
@@ -149,7 +149,6 @@ export default {
   },
   computed: {
     ...mapState({
-      lazyLoad: (state) => state.lazyLoad,
       schedule: (state) => state.splus.schedule
     }),
     ...mapGetters({
@@ -165,10 +164,8 @@ export default {
     }
   },
   mounted () {
-    if (this.lazyLoad) {
-      // static build -> no events are in the store
-      this.refresh();
-    }
+    // force refresh to avoid using outdated cache
+    this.refresh();
   },
   methods: {
     ...mapMutations({

--- a/web/pages/bus.vue
+++ b/web/pages/bus.vue
@@ -25,7 +25,7 @@
 
           <v-list>
             <v-list-item
-              v-for="departure in departures[direction]"
+              v-for="departure in removePastDepartures(departures[direction])"
               :key="departure.date"
             >
               <v-list-item-content
@@ -91,8 +91,7 @@ export default {
   },
   computed: {
     ...mapState({
-      departures: (state) => state.bus.departures,
-      lazyLoad: (state) => state.lazyLoad
+      departures: (state) => state.bus.departures
     })
   },
   mounted () {
@@ -111,7 +110,11 @@ export default {
     }),
     ...mapMutations({
       setSidenav: 'ui/setSidenav'
-    })
+    }),
+    removePastDepartures (departures) {
+    // remove all departures older than 10 minutes ago
+      return departures.filter(dep => (this.minutesUntilDate(dep.date) > -10));
+    }
   },
   middleware: 'cached'
 };

--- a/web/pages/bus.vue
+++ b/web/pages/bus.vue
@@ -113,7 +113,7 @@ export default {
     }),
     removePastDepartures (departures) {
     // remove all departures older than 10 minutes ago
-      return departures.filter(dep => (this.minutesUntilDate(dep.date) > -10));
+      return departures ? departures.filter(dep => (this.minutesUntilDate(dep.date) > -10)) : null;
     }
   },
   middleware: 'cached'

--- a/web/pages/mensa.vue
+++ b/web/pages/mensa.vue
@@ -119,8 +119,7 @@ export default {
   },
   computed: {
     ...mapState({
-      plans: (state) => state.mensa.plans,
-      lazyLoad: (state) => state.lazyLoad
+      plans: (state) => state.mensa.plans
     }),
     groupedDayPlans () {
       if (!this.plans) return [];

--- a/web/plugins/pwa-update.js
+++ b/web/plugins/pwa-update.js
@@ -9,7 +9,7 @@ export default async (context) => {
   workbox.addEventListener('installed', (event) => {
     if (!event.isUpdate) return
 
-    console.debug('There is an update for the PWA, reloading...')
+    console.debug('Update for the PWA available, reloading the page...')
     window.location.reload()
   })
 }

--- a/web/store/news.js
+++ b/web/store/news.js
@@ -27,10 +27,6 @@ export const actions = {
       console.error('error during News API call (Fakultät-News)', error.message);
     }
   },
-  async setFaculty ({ commit, dispatch }, faculty) {
-    commit('setFaculty', faculty);
-    dispatch('loadFacultyNews');
-  },
   async loadCampusNews ({ commit }) {
     const campusSelectors = ['campus', 'campus38'];
     try {


### PR DESCRIPTION
* vuex-persist is too slow, which is why the faculty news always showed "wolfenbüttel", this is fixed by implementing a watcher (bug added with #463)
* hide old bus departures (because it looks bad if all departures are a few days ago when there's no network)
* always refresh timetable to avoid outdated stuff in PWA