### PR TITLE
Improve bus layout, use skeleton loaders

### DIFF
--- a/web/pages/bus.vue
+++ b/web/pages/bus.vue
@@ -1,29 +1,35 @@
 <template>
   <v-container
     fluid
+    class="mt-3 px-4"
   >
-    <v-row dense>
+    <v-row
+      justify="center"
+    >
       <v-col
         v-for="direction in directions"
         :key="direction"
         cols=12
-        md=auto
-        class="flex-grow-1"
+        md=5
+        xl=3
       >
-        <v-card>
+        <v-card
+          v-if="departures"
+          class="pa-2"
+        >
           <v-card-title>
             <div class="text-h5">
               {{ directionLabel[direction] }}
             </div>
           </v-card-title>
 
-          <v-list dense>
+          <v-list>
             <v-list-item
               v-for="departure in departures[direction]"
               :key="departure.date"
             >
               <v-list-item-content
-                class="pb-0"
+                class="pb-0 pt-1"
               >
                 <p>
                   <v-chip
@@ -42,10 +48,14 @@
             </v-list-item>
           </v-list>
         </v-card>
+        <v-skeleton-loader
+          v-else
+          type="article"
+        />
       </v-col>
     </v-row>
 
-    <span class="pt-1 d-flex justify-end text-caption text--secondary">
+    <span class="pt-4 d-flex justify-end text-caption text--secondary">
       Quelle: Deutsche Bahn HAFAS
     </span>
   </v-container>

--- a/web/store/bus.js
+++ b/web/store/bus.js
@@ -1,5 +1,5 @@
 export const state = () => ({
-  departures: []
+  departures: null
 });
 
 export const mutations = {


### PR DESCRIPTION
make cards smaller to fit content and show skeleton loaders when still loading (noticable on slower connections)

![image](https://user-images.githubusercontent.com/12055376/129270900-f25ea535-73f7-40a4-ab40-7b258d004988.png)


![image](https://user-images.githubusercontent.com/12055376/129270855-0996fbb9-cfac-4dcf-b250-007aa1263108.png)

![image](https://user-images.githubusercontent.com/12055376/129270997-08994b93-6136-45bd-b6a8-d243f2882e4b.png)
