### PR TITLE
fix(side-nav): fixed mobile sidebar scrolling issue

### DIFF
--- a/web/components/spluseins-side-nav.vue
+++ b/web/components/spluseins-side-nav.vue
@@ -8,6 +8,7 @@
     fixed
     app
     width="350"
+    :class="{'mobile-scroll-drawer': isMobile}"
   >
     <basic-utilities-list />
     <v-divider v-if="hasCustomTimetables" />
@@ -52,6 +53,9 @@ export default {
     hasFavoriteTimetables () {
       return this.favoriteSchedules.length > 0;
     },
+    isMobile () {
+      return this.$vuetify.breakpoint.mobile;
+    },
     ...mapState({
       customSchedules: (state) => state.splus.customSchedules,
       favoriteSchedules: (state) => state.splus.favoriteSchedules,
@@ -68,6 +72,14 @@ export default {
 </script>
 
 <style lang="scss">
+.mobile-scroll-drawer {
+  max-height: 100%;
+
+  @supports (height: 100dvh) {
+    max-height: 100dvh;
+  }
+}
+
 .stick-bottom {
   position: sticky;
   bottom: 0;


### PR DESCRIPTION
Hi!

On mobile devices (for example my Google Pixel 8a), the sidebar (v-navigation-drawer) could not be fully scrolled, causing some entries (e.g., "Versorgungstechnik Bachelor" and "Wirtschaft Bachelor") to be partially or completely inaccessible. On desktop everything is working as expected. It looks like the cause of this is the inline CSS `height: 100vh` thats applied to the `<nav>` element (looks like that's the default of v-navigation-drawer?). This issue could also be fixed by just passing `height: 100dvh` to the v-navigation-drawer, however using this approach I couldn't find a way to add a fallback for older browsers.

This PR includes:
- Added mobile-scroll-drawer class that sets the max-height to 100% for legacy devices or the newer [dvh](https://caniuse.com/mdn-css_types_length_viewport_percentage_units_dynamic) (if supported by the browser).
- isMobile check to ensure this class is only used when needed (code taken from [calendar-action-bar.vue](https://github.com/SplusEins/SplusEins/blob/master/web/components/calendar-action-bar.vue#L157))

