### PR TITLE
fix: update Motis client initialization to disable enrichStations

### DIFF
--- a/server/controllers/bus.ts
+++ b/server/controllers/bus.ts
@@ -5,8 +5,12 @@ import * as fsStore from 'cache-manager-fs-hash';
 import { createClient } from '@motis-project/motis-fptf-client'
 import { profile } from '@motis-project/motis-fptf-client/p/transitous'
 
-// create a client with Transitous profile
-const motisClient = createClient(profile, 'spluseins.de/team@spluseins.de/05.09.25') // in case of changes, adjust the version date accordingly
+// create a client with Transitous profile (disable station enrichment to avoid import/path issues with db-hafas-stations)
+const motisClient = createClient(
+  profile,
+  'spluseins.de/team@spluseins.de/05.11.25',
+  { enrichStations: false }
+); // in case of changes, adjust the version date accordingly
 
 // default must be in /tmp because the rest is RO on AWS Lambda
 const CACHE_PATH = process.env.CACHE_PATH || '/tmp/spluseins-cache';


### PR DESCRIPTION
Sollte folgenden Fehler "fixen" (umgehen), der vermutlich (?) in Kombination mit der [db-hafas-stations](https://github.com/derhuerst/db-hafas-stations/blob/master/index.js) Bibliothek und dem dokku/buildpack-Setup auftritt:
```
Error: ENOENT: no such file or directory, open '/tmp/build/node_modules/db-hafas-stations/full.ndjson'
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/tmp/build/node_modules/db-hafas-stations/full.ndjson'
}
```
Laut @Dennis960 sucht db-hafas-stations nach `/tmp/build/node_modules/db-hafas-stations` aber nach dem Build landet die Datei in `node_modules/db-hafas-stations/full.ndjson`.
Idee zum "umbiegen" von motis, um den Import zu vermeiden von @schneefux 

Auszug Discord:
Wenn wir den `createClient` Aufruf (https://github.com/SplusEins/SplusEins/blob/master/server/controllers/bus.ts#L9) anpassen und `enrichStations` auf false setzen (`const motisClient = createClient(profile, 'spluseins.de/team@spluseins.de/05.09.25',  { enrichStations: false });`) sollte die db-hafas-station nicht mehr importiert werden

- createClient motis source (hier wird basierend auf dem opt Objekt shouldLoadEnrichedStationData  gesetzt) https://github.com/motis-project/motis-fptf-client/blob/master/index.js#L58
- journeys applyEnrichedStationData call (das ist der Startpunkt der den späteren db-hafas-stations import auslöst) https://github.com/motis-project/motis-fptf-client/blob/master/index.js#L150
- loadEnrichedStationData Funktion mit db-hafas-import (wird von applyEnrichedStationData aufgerufen) https://github.com/motis-project/motis-fptf-client/blob/master/index.js#L30C7-L30C31