### PR TITLE
Faculty h add room/lecturer, enhance organiser name censoring/shortname generation

### DIFF
--- a/server/lib/SkedParser.ts
+++ b/server/lib/SkedParser.ts
@@ -196,6 +196,7 @@ export function parseSkedGraphical(html: string, faculty: string): ParsedLecture
       .replace(/\s\[\d+\]/g, ''))); // replace footnote links: e.g. [1]
 
     cols.forEach(col => {
+      // eslint-disable-next-line complexity
       col.forEach((entry, index) => {
         if (index === 0) {
           // is date
@@ -236,9 +237,10 @@ export function parseSkedGraphical(html: string, faculty: string): ParsedLecture
             anmerkung = parts[1];
             break;
           case 'Handel und Soziale Arbeit':
-            // Leider ohne Dozent / Raum, da die Zeilen in dieser Fakultät zu unterschiedlich genutzt werden
-            veranstaltung = parts[2];
-            anmerkung = parts[1];
+            veranstaltung = parts.at(2) || '';
+            anmerkung = parts.at(1) || '';
+            raum = parts.at(-1) || '';
+            dozent = parts.at(-2) || '';
             break;
           case 'Wirtschaft':
             // Leider ohne Dozent / Raum, da die Zeilen in dieser Fakultät zu unterschiedlich genutzt werden

--- a/server/model/SplusEinsModel.ts
+++ b/server/model/SplusEinsModel.ts
@@ -113,20 +113,35 @@ export class Event {
     return crypto.createHash('sha1').update(title).digest('base64').replace(/[/+=]/g, '').slice(0, 5);
   }
 
-  private censorOrganiserName (name: string): string {
-    return name.split(' ').map(part =>
-      (new RegExp('Prof|Dr|Dipl|Ing|Inform|Herr|Frau|MA|BA|rer.|nat.|Master|Bachelor', 'g').test(part)) || part.length < 3 ? part : part.charAt(0) + '.')
-      .join(' ')
+  private censorOrganiserName(name: string): string {
+    const titles = /^(Prof\.?|Dr\.?|Dipl\.?|Ing\.?|Inform\.?|Herr|Frau|MA|BA|rer\.|nat\.|Master|Bachelor)$/i;
+    return name
+      .split(',')
+      .map(part => part.trim().split(/\s+/)
+        .map(word => titles.test(word) || word.length < 3 ? word : word[0] + '.')
+        .join(' ')
+      )
+      .join(', ');
   }
 
-  private generateOrganiserShortname (lecturer: string): string {
+  private generateOrganiserShortname(lecturer: string): string {
+    const titles = /^(Prof\.?|Dr\.?|Dipl\.?|Ing\.?|Inform\.?|Herr|Frau|MA|BA|rer\.|nat\.|Master|Bachelor)$/i;
     return lecturer
-      .replace(/Prof|Dr|Dipl|Ing|Inform|Herr|Frau|MA|BA|rer.|nat.|Master|Bachelor/g, '')
-      .replace('ä', 'ae').replace('ö', 'oe').replace('ü', 'ue').replace('ß', 'ss')
-      .replace(/[^a-z]/gi, ' ')
-      .split(' ')
-      .filter((w) => ![' ', ''].includes(w))
-      .join(' ');
+      .split(',')
+      .map(part => part.trim().split(/\s+/)
+        .filter(word => !titles.test(word) && word.length > 0)
+        .map(word => word
+          .replace(/[äÄ]/g, 'ae')
+          .replace(/[öÖ]/g, 'oe')
+          .replace(/[üÜ]/g, 'ue')
+          .replace(/ß/g, 'ss')
+          .replace(/[^a-zA-Z]/g, '')
+        )
+        .filter(Boolean)
+        .map(word => word[0])
+        .join(' ')
+      )
+      .join(', ');
   }
 
   constructor (lecture: ParsedLecture) {


### PR DESCRIPTION
- Improved faculty h event parsing:
    - Room and lecturer fields are now supported for "Handel und Soziale Arbeit".
    - Array [.at()](https://caniuse.com/?search=Array.at) is used instead of direct index access for safer parsing.
- Organiser name handling:
    - Multiple lecturers in a field are now correctly listed as comma-separated short names.