### PR TITLE
Fix Pull OSM Workflow

### DIFF
--- a/.github/workflows/pull-osm-changes.yml
+++ b/.github/workflows/pull-osm-changes.yml
@@ -16,18 +16,18 @@ jobs:
           ssh-key: ${{ secrets.SSH_GITHUB_PRIVATE_KEY }}
           fetch-depth: 0
 
-      - name: Run getLocationLinks
+      - name: Run getRoomIds
         shell: bash
         run: |
           set -o pipefail
-          server/scripts/getLocationLinks.sh 2>&1 | tee osm-fetch.log
+          server/scripts/getRoomIds.sh 2>&1 | tee osm-fetch.log
 
       - name: Check for errors
         shell: bash
         run: |
-          if grep -qi "error\|failed" osm-fetch.log; then
+          if grep -qi "error" osm-fetch.log; then
             echo "[!!!] Errors detected in OSM fetch:"
-            grep -i "error\|failed" osm-fetch.log
+            grep -i "error" osm-fetch.log
             exit 1
           fi
 


### PR DESCRIPTION
- `Pull OSM changes` Workflow Änderungen:
  - Name vom Workflowschritt ist jetzt der neue Skriptname (`Run getLocationLinks` -> `Run getRoomIds`)
  - Ruft jetzt das Skript mit dem neuen Namen auf (`getLocationLinks` -> `getRoomIds` in #1136)
  - `Check for errors` Schritt löst nicht mehr zu früh bzw. fälschlicherweise aus (pro Standort gibt wird drei mal der Request versuchst, wenn ein Request fehlschlägt wird "Attempt $i failed" ausgegeben, was diesen Check schon auslösen lässt, obwohl ein nachfolgender Request erfolgreich war)