### PR TITLE
Parse Maschinenbau timetables without times in elements

### DIFF
--- a/server/lib/SkedParser.ts
+++ b/server/lib/SkedParser.ts
@@ -192,6 +192,7 @@ export function parseSkedGraphical(
       true,
       true,
       false,
+      (faculty === "Maschinenbau"),
     );
 
     cols = cols.filter((c) => c[0].length > 0); // filter pseudo columns -> first entry is not date string
@@ -301,6 +302,7 @@ export function parseSkedGraphical(
           case 'Gesundheitswesen':
           case 'Verkehr-Sport-Tourismus-Medien':
           case 'Elektro- und Informationstechnik':
+          case 'Maschinenbau':
             if (parts.length === 3) {
               // some special handling for faculty E entries
               veranstaltung = parts[1];

--- a/server/lib/SkedParser.ts
+++ b/server/lib/SkedParser.ts
@@ -192,7 +192,7 @@ export function parseSkedGraphical(
       true,
       true,
       false,
-      (faculty === "Maschinenbau"),
+      faculty === 'Maschinenbau',
     );
 
     cols = cols.filter((c) => c[0].length > 0); // filter pseudo columns -> first entry is not date string

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -2,10 +2,31 @@
  * https://github.com/misterparser/cheerio-tableparser/blob/master/index.js
  */
 
-export default function parseTable($, dupCols, dupRows, textMode) {
+export default function parseTable($, dupCols, dupRows, textMode, estimateTimes) {
   if (dupCols === undefined) dupCols = false;
   if (dupRows === undefined) dupRows = false;
   if (textMode === undefined) textMode = false;
+  if (estimateTimes === undefined) estimateTimes = false;
+
+
+  let startTime;
+  let timeGrid;
+  if (estimateTimes) {
+    let times = [];
+    $('tr').each((row_idx, row) => {
+      let content = $('td:first', row).html();
+      // Find time labels at the side of the timetable
+      if (/^\d?\d:\d\d$/g.test(content)) {
+        times.push({
+          index: row_idx,
+          time: new Date(0, 0, 0, parseInt(content.split(':')[0]), parseInt(content.split(':')[1]), 0)
+        });
+      }
+    });
+    // Calculate row length in minutes and start time of the timetable
+    timeGrid = (times[1].time - times[0].time) / (times[1].index - times[0].index) / (60 * 1000);
+    startTime = addMinutes(times[0].time, -1 * timeGrid * times[0].index);
+  }
 
   const columns = [];
   let curr_x = 0;
@@ -20,6 +41,19 @@ export default function parseTable($, dupCols, dupRows, textMode) {
         content = $(col).text().trim() || '';
       } else {
         content = $(col).html() || '';
+
+        if (estimateTimes) {
+          // Add time string to html if cell is an event and has no time
+          if (!/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) && $(col).text().trim() != "" && !/\d?\d:\d\d/gm.test($(col).text().trim()) && !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())) {
+            content = addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString('de-de', {
+              hour: 'numeric',
+              minute: '2-digit',
+            }) + ' - ' + addMinutes(startTime, (row_idx + parseInt(rowspan)) * timeGrid).toLocaleTimeString('de-de', {
+              hour: 'numeric',
+              minute: '2-digit',
+            }) + ' Uhr<br>' + content;
+          }
+        }
       }
 
       let x = 0;
@@ -50,4 +84,8 @@ export default function parseTable($, dupCols, dupRows, textMode) {
   });
 
   return columns;
+}
+
+function addMinutes(date, minutes) {
+  return new Date(date.getTime() + minutes * 60000);
 }

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -60,7 +60,6 @@ export default function parseTable(
         if (estimateTimes) {
           // Add time string to html if cell is an event and has no time
           if (
-            !/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) &&
             $(col).text().trim() !== '' &&
             !/\d?\d:\d\d/gm.test($(col).text().trim()) &&
             !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -68,7 +68,7 @@ export default function parseTable(
           ) {
             if (!startTime || !timeGrid) {
               // Add a blank line instead of the times if row length or start time could not be calculated
-              content = "<br>" + content;
+              content = '<br>' + content;
             } else {
               content =
                 addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString(

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -2,12 +2,17 @@
  * https://github.com/misterparser/cheerio-tableparser/blob/master/index.js
  */
 
-export default function parseTable($, dupCols, dupRows, textMode, estimateTimes) {
+export default function parseTable(
+  $,
+  dupCols,
+  dupRows,
+  textMode,
+  estimateTimes,
+) {
   if (dupCols === undefined) dupCols = false;
   if (dupRows === undefined) dupRows = false;
   if (textMode === undefined) textMode = false;
   if (estimateTimes === undefined) estimateTimes = false;
-
 
   let startTime;
   let timeGrid;
@@ -19,12 +24,22 @@ export default function parseTable($, dupCols, dupRows, textMode, estimateTimes)
       if (/^\d?\d:\d\d$/g.test(content)) {
         times.push({
           index: row_idx,
-          time: new Date(0, 0, 0, parseInt(content.split(':')[0]), parseInt(content.split(':')[1]), 0)
+          time: new Date(
+            0,
+            0,
+            0,
+            parseInt(content.split(':')[0]),
+            parseInt(content.split(':')[1]),
+            0,
+          ),
         });
       }
     });
     // Calculate row length in minutes and start time of the timetable
-    timeGrid = (times[1].time - times[0].time) / (times[1].index - times[0].index) / (60 * 1000);
+    timeGrid =
+      (times[1].time - times[0].time) /
+      (times[1].index - times[0].index) /
+      (60 * 1000);
     startTime = addMinutes(times[0].time, -1 * timeGrid * times[0].index);
   }
 
@@ -44,14 +59,30 @@ export default function parseTable($, dupCols, dupRows, textMode, estimateTimes)
 
         if (estimateTimes) {
           // Add time string to html if cell is an event and has no time
-          if (!/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) && $(col).text().trim() !== "" && !/\d?\d:\d\d/gm.test($(col).text().trim()) && !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())) {
-            content = addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString('de-de', {
-              hour: 'numeric',
-              minute: '2-digit',
-            }) + ' - ' + addMinutes(startTime, (row_idx + parseInt(rowspan)) * timeGrid).toLocaleTimeString('de-de', {
-              hour: 'numeric',
-              minute: '2-digit',
-            }) + ' Uhr<br>' + content;
+          if (
+            !/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) &&
+            $(col).text().trim() !== '' &&
+            !/\d?\d:\d\d/gm.test($(col).text().trim()) &&
+            !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())
+          ) {
+            content =
+              addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString(
+                'de-de',
+                {
+                  hour: 'numeric',
+                  minute: '2-digit',
+                },
+              ) +
+              ' - ' +
+              addMinutes(
+                startTime,
+                (row_idx + parseInt(rowspan)) * timeGrid,
+              ).toLocaleTimeString('de-de', {
+                hour: 'numeric',
+                minute: '2-digit',
+              }) +
+              ' Uhr<br>' +
+              content;
           }
         }
       }

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -36,11 +36,13 @@ export default function parseTable(
       }
     });
     // Calculate row length in minutes and start time of the timetable
-    timeGrid =
-      (times[1].time - times[0].time) /
-      (times[1].index - times[0].index) /
-      (60 * 1000);
-    startTime = addMinutes(times[0].time, -1 * timeGrid * times[0].index);
+    if (times.length >= 2) {
+      timeGrid =
+        (times[1].time - times[0].time) /
+        (times[1].index - times[0].index) /
+        (60 * 1000);
+      startTime = addMinutes(times[0].time, -1 * timeGrid * times[0].index);
+    }
   }
 
   const columns = [];
@@ -64,24 +66,29 @@ export default function parseTable(
             !/\d?\d:\d\d/gm.test($(col).text().trim()) &&
             !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())
           ) {
-            content =
-              addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString(
-                'de-de',
-                {
+            if (!startTime || !timeGrid) {
+              // Add a blank line instead of the times if row length or start time could not be calculated
+              content = "<br>" + content;
+            } else {
+              content =
+                addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString(
+                  'de-de',
+                  {
+                    hour: 'numeric',
+                    minute: '2-digit',
+                  },
+                ) +
+                ' - ' +
+                addMinutes(
+                  startTime,
+                  (row_idx + parseInt(rowspan)) * timeGrid,
+                ).toLocaleTimeString('de-de', {
                   hour: 'numeric',
                   minute: '2-digit',
-                },
-              ) +
-              ' - ' +
-              addMinutes(
-                startTime,
-                (row_idx + parseInt(rowspan)) * timeGrid,
-              ).toLocaleTimeString('de-de', {
-                hour: 'numeric',
-                minute: '2-digit',
-              }) +
-              ' Uhr<br>' +
-              content;
+                }) +
+                ' Uhr<br>' +
+                content;
+            }
           }
         }
       }

--- a/server/lib/parseTable.ts
+++ b/server/lib/parseTable.ts
@@ -12,9 +12,9 @@ export default function parseTable($, dupCols, dupRows, textMode, estimateTimes)
   let startTime;
   let timeGrid;
   if (estimateTimes) {
-    let times = [];
+    const times = [];
     $('tr').each((row_idx, row) => {
-      let content = $('td:first', row).html();
+      const content = $('td:first', row).html();
       // Find time labels at the side of the timetable
       if (/^\d?\d:\d\d$/g.test(content)) {
         times.push({
@@ -44,7 +44,7 @@ export default function parseTable($, dupCols, dupRows, textMode, estimateTimes)
 
         if (estimateTimes) {
           // Add time string to html if cell is an event and has no time
-          if (!/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) && $(col).text().trim() != "" && !/\d?\d:\d\d/gm.test($(col).text().trim()) && !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())) {
+          if (!/\d?\d:\d\d - \d?\d:\d\d Uhr<br>.*/gm.test(content) && $(col).text().trim() !== "" && !/\d?\d:\d\d/gm.test($(col).text().trim()) && !/.., \d\d\.\d\d\.\d\d\d\d/gm.test($(col).text().trim())) {
             content = addMinutes(startTime, row_idx * timeGrid).toLocaleTimeString('de-de', {
               hour: 'numeric',
               minute: '2-digit',

--- a/timetable-config.yaml
+++ b/timetable-config.yaml
@@ -47,9 +47,8 @@ plans:
     faculty: Verkehr-Sport-Tourismus-Medien
   - url: https://stundenplan.ostfalia.de/k/prod/vorlesungsplaene/wp/ws/
     faculty: Verkehr-Sport-Tourismus-Medien
-  # Die Timetables haben keine Uhrzeit in den einzelnen Elementen => zu hart für SplusEins
-  # - url: https://stundenplan.ostfalia.de/m/sem/index.html
-  #  faculty: Maschinenbau
+  - url: https://stundenplan.ostfalia.de/m/sem/index.html
+    faculty: Maschinenbau
   - url: https://stundenplan.ostfalia.de/r/studentenset/index.html
     faculty: Recht
   - url: https://stundenplan.ostfalia.de/s/wp/index.html


### PR DESCRIPTION
Ich habe die Möglichkeit hinzugefügt, auch die Maschinenbau Stundenpläne ohne Uhrzeiten zu parsen.
Die Uhrzeiten werden aus den Positionen der Objekte berechnet und als String vor den HTML-Text der Veranstaltung hinzugefügt, sodass der Parser eine normale Veranstaltung mit Uhrzeiten erhält.
Die Reihenfolge der restlichen Felder entspricht den Elektrotechnik Stundenplänen.

Die Stundenpläne werden allerdings nicht nach Semester sortiert.